### PR TITLE
VOTE-248: allow spaces in City and Party inputs

### DIFF
--- a/src/components/FormSections/ValidateField.jsx
+++ b/src/components/FormSections/ValidateField.jsx
@@ -12,7 +12,7 @@ export const focusNext=(e, nextId, type)=>{
 
 export const restrictType = (e, requiredType) => {
   let allowKeys = ['Backspace', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'Tab']
-  let letters = /^[A-Za-z-]+$/;
+  let letters = /^[A-Za-z\s]*$/;
 
   if (allowKeys.includes(e.key)) {
     return;


### PR DESCRIPTION
[VOTE-248](https://cm-jira.usa.gov/browse/VOTE-248)

Test by using the City input under Personal Information section of the form. It should only allow spaces and alphabetical letters.