### PR TITLE
VOTE-279: update the markup of input field examples

### DIFF
--- a/src/components/FormSections/Addresses.jsx
+++ b/src/components/FormSections/Addresses.jsx
@@ -146,8 +146,8 @@ function Addresses(props){
                     </Label>
 
                     <div className={validationStyles[(addressReq && handleErrors.zip) && 'error-container']}>
-                        <Label htmlFor="zip">
-                            Zip Code (12345){addressReq && <span className={validationStyles['required-text']}>*</span>}
+                        <legend htmlFor="zip" class="usa-legend">Zip Code {addressReq && <span className={validationStyles['required-text']}>*</span>}</legend>
+                        <span class="usa-hint" id="date-of-birth-hint">For example: 12345</span>
                         <TextInput 
                             id="zip" 
                             aria-describedby="zip-error"
@@ -168,7 +168,6 @@ function Addresses(props){
                                     Zip Code must be 5 digits.
                                 </span>
                         }
-                        </Label>
                     </div>
 
                     { changeRegistrationVisible && (
@@ -256,8 +255,8 @@ function Addresses(props){
                                     </div>
 
                                     <div className={validationStyles[(addressReq && handleErrors.prev_zip) && 'error-container']}>
-                                        <Label htmlFor="prev-zip">
-                                            Zip Code (12345){addressReq && <span className={validationStyles['required-text']}>*</span>}
+                                        <legend htmlFor="prev-zip" class="usa-legend">Zip Code {addressReq && <span className={validationStyles['required-text']}>*</span>}</legend>
+                                        <span class="usa-hint" id="date-of-birth-hint">For example: 12345</span>
                                         <TextInput 
                                             id="prev-zip" 
                                             aria-describedby="prev-zip-error"
@@ -278,7 +277,6 @@ function Addresses(props){
                                                 Previous Zip Code must be 5 digits.
                                             </span>
                                         }
-                                        </Label>
                                     </div>
                                 </div>
                             )}
@@ -367,8 +365,8 @@ function Addresses(props){
                                     </div>
 
                                     <div className={validationStyles[(addressReq && handleErrors.mail_zip) && 'error-container']}>
-                                        <Label htmlFor="mail-zip">
-                                            Zip Code (12345){addressReq && <span className={validationStyles['required-text']}>*</span>}
+                                        <legend htmlFor="mail-zip" class="usa-legend">Zip Code {addressReq && <span className={validationStyles['required-text']}>*</span>}</legend>
+                                        <span class="usa-hint" id="date-of-birth-hint">For example: 12345</span>
                                         <TextInput 
                                             id="mail-zip"
                                             aria-describedby="mail-zip-error" 
@@ -389,7 +387,6 @@ function Addresses(props){
                                                Mailing Zip Code must be 5 digits.
                                             </span>
                                         }
-                                        </Label>
                                     </div>
                                 </div>
                             )}

--- a/src/components/FormSections/PersonalInfo.jsx
+++ b/src/components/FormSections/PersonalInfo.jsx
@@ -327,7 +327,7 @@ function PersonalInfo(props){
                     </div>
                 </Fieldset>
             {(dobReq && handleErrors.dob) && 
-                <span id="dob-error" rol="alert" className={validationStyles['error-text']}>
+                <span id="dob-error" role="alert" className={validationStyles['error-text']}>
                     Date of Birth must follow the format of January 19 2000.
                 </span>
             }
@@ -336,7 +336,8 @@ function PersonalInfo(props){
 
         {telephoneVisible && (
             <div className={validationStyles[(telephoneReq && handleErrors.phone_number) && 'error-container']}>
-                <Label htmlFor="phone-number">Phone Number (123) 456-7890{telephoneReq && <span className={validationStyles['required-text']}>*</span>}
+                <legend htmlFor="phone-number" class="usa-legend">Phone Number{telephoneReq && <span className={validationStyles['required-text']}>*</span>}</legend>
+                <span class="usa-hint" id="date-of-birth-hint">For example: (123) 456-7890</span>
                 <TextInput 
                     id="phone-number" 
                     aria-describedby="phone-number-error"
@@ -351,11 +352,10 @@ function PersonalInfo(props){
                     onBlur={(e) => setHandleErrors({ ...handleErrors, phone_number: checkForErrors(e, 'check value length') })}
                 />
                 {(telephoneReq && handleErrors.phone_number) && 
-                    <span id="phone-number-error" rol="alert" className={validationStyles['error-text']}>
+                    <span id="phone-number-error" role="alert" className={validationStyles['error-text']}>
                         Phone number must be 10 digits.
                     </span>
                 }
-                </Label>
             </div>
         )}
 


### PR DESCRIPTION
[VOTE-279](https://cm-jira.usa.gov/browse/VOTE-279)

Examples for field inputs should use consistent formatting 