### PR TITLE
VOTE-339 Hide the // in id date fields when empty

### DIFF
--- a/src/components/FormSections/Confirmation.jsx
+++ b/src/components/FormSections/Confirmation.jsx
@@ -14,6 +14,10 @@ function Confirmation(props){
     const fieldDataOverride_state = props.stateData.name;
     fieldData.state = fieldDataOverride_state;
 
+    //field data overrides for id dates
+    const fieldDataOverride_id_issue_date = (fieldData.id_issue_date_month === '') ? "" : `${fieldData.id_issue_date_month}/${fieldData.id_issue_date_day}/${fieldData.id_issue_date_year}`;
+    const fieldDataOverride_id_expire_date = (fieldData.id_expire_date_month === '') ? "" : `${fieldData.id_expire_date_month}/${fieldData.id_expire_date_day}/${fieldData.id_expire_date_year}`;
+
     //Acknowledgment field controls
     const [hasAcknowledged, setHasAcknowledged] = useState(null);
     const [error, setError] = useState(null)
@@ -142,8 +146,8 @@ function Confirmation(props){
         </h3>
         <ul>
             <li>ID number: {fieldData.id_number}</li>
-            <li>ID issue date: {fieldData.id_issue_date_month}/{fieldData.id_issue_date_day}/{fieldData.id_issue_date_year}</li>
-            <li>ID expire date: {fieldData.id_expire_date_month}/{fieldData.id_expire_date_day}/{fieldData.id_expire_date_year}</li>
+            <li>ID issue date: {fieldDataOverride_id_issue_date} </li>
+            <li>ID expire date: {fieldDataOverride_id_expire_date}</li>
         </ul>
         <hr />
         <h3>Choice of Political Party


### PR DESCRIPTION
Jira: https://cm-jira.usa.gov/browse/VOTE-339

Test steps:
1. Fill out the form, the first time filling out the date id fields, and stop on the confirm page.
2. Confirm the id dates have the format of month/day/year
3. Click "edit" next to Identification. Clear the dates, and select "none" from the drop down
4. Go back to the confirm page and verify the id date fields show up empty (without any slashes "//")