### PR TITLE
Vote-408: ND state link update

### DIFF
--- a/src/components/RegType/NotNeeded.jsx
+++ b/src/components/RegType/NotNeeded.jsx
@@ -17,7 +17,7 @@ function NotNeeded(props) {
                 </Link>
             )}</p>
             <p>
-                <a href={state.election_website_url}><Button type="button">
+                <a href={state.election_website_url} target="_blank"><Button type="button">
                     {content.more_button}
                     <Icon.Launch title="External link opens new window"/>
                 </Button>


### PR DESCRIPTION
Ticket: [Vote-408](https://cm-jira.usa.gov/browse/VOTE-408)
Purpose: This Pr will update the link opening to the state election page opening to a new tab... before it was opening in the same tab
Testing:
1 - visit [preview](https://federalist-aef5b597-8e18-44b6-aeba-3fc3f17cdac1.sites.pages.cloud.gov/preview/usagov/vote-gov-nvrf-app/bug/vote-408-nd-link/) and select North Dakota as a state option and click both the state links and ensure they both open into a new tab
