### PR TITLE
Bugfix/vote 549/data fields reset

### DIFF
--- a/src/components/FormSections/Confirmation.jsx
+++ b/src/components/FormSections/Confirmation.jsx
@@ -12,6 +12,7 @@ function Confirmation(props){
     const prevName = fieldData.prev_title + fieldData.prev_first_name + fieldData.prev_middle_name + fieldData.prev_last_name + fieldData.prev_suffix;
     const prevAddress = fieldData.prev_street_address + fieldData.prev_apt_num + fieldData.prev_city + fieldData.prev_state + fieldData.prev_zip_code;
     const prevMailAddress = fieldData.mail_street_address + fieldData.mail_apt_num + fieldData.mail_city + fieldData.mail_state + fieldData.mail_zip_code;
+    const permanentAddress = fieldData.street_address + fieldData.apt_num + fieldData.city + fieldData.state + fieldData.zip_code;
 
 
     //field data overrides for confirm page printing only
@@ -84,6 +85,11 @@ function Confirmation(props){
             </Button>
             </span>
                     </h2>
+                    {!permanentAddress && (
+                        <Alert type="info" headingLevel="h4" noIcon>
+                            You are not registering with a current address, so these fields are blank.
+                        </Alert>
+                    )}
                     <p><strong>Current Address</strong></p>
                     <ul>
                         <li>Street Address: {fieldData.street_address}</li>

--- a/src/components/FormSections/Confirmation.jsx
+++ b/src/components/FormSections/Confirmation.jsx
@@ -12,8 +12,6 @@ function Confirmation(props){
     const prevName = fieldData.prev_title + fieldData.prev_first_name + fieldData.prev_middle_name + fieldData.prev_last_name + fieldData.prev_suffix;
     const prevAddress = fieldData.prev_street_address + fieldData.prev_apt_num + fieldData.prev_city + fieldData.prev_state + fieldData.prev_zip_code;
     const prevMailAddress = fieldData.mail_street_address + fieldData.mail_apt_num + fieldData.mail_city + fieldData.mail_state + fieldData.mail_zip_code;
-    const permanentAddress = fieldData.street_address + fieldData.apt_num + fieldData.city + fieldData.state + fieldData.zip_code;
-
 
     //field data overrides for confirm page printing only
     const fieldDataOverride_race = (fieldData.race === '') ? "Not required for your state" : fieldData.race;
@@ -85,11 +83,6 @@ function Confirmation(props){
             </Button>
             </span>
                     </h2>
-                    {!permanentAddress && (
-                        <Alert type="info" headingLevel="h4" noIcon>
-                            You are not registering with a current address, so these fields are blank.
-                        </Alert>
-                    )}
                     <p><strong>Current Address</strong></p>
                     <ul>
                         <li>Street Address: {fieldData.street_address}</li>

--- a/src/components/MultiStepForm.jsx
+++ b/src/components/MultiStepForm.jsx
@@ -23,18 +23,17 @@ function MultiStepForm(props) {
     //Field data controls
     const [fieldData, setFieldData] = useState({
         title:'', first_name: '', middle_name: '', last_name: '', suffix:'',
-        prev_name_check: false, prev_title:'', prev_first_name: '', prev_middle_name: '', prev_last_name: '', prev_suffix:'',
+        prev_title:'', prev_first_name: '', prev_middle_name: '', prev_last_name: '', prev_suffix:'',
         date_of_birth_month:'', date_of_birth_day:'', date_of_birth_year:'', phone_number:'',race:'',
         street_address:'', apt_num:'', city:'', state:'', zip_code:'',
-        prev_address_check: false, prev_street_address:'', prev_apt_num:'', prev_city:'', prev_state:'', prev_zip_code:'',
-        mail_address_check: false, mail_street_address:'', mail_apt_num:'', mail_city:'', mail_state:'', mail_zip_code:'',
+        prev_street_address:'', prev_apt_num:'', prev_city:'', prev_state:'', prev_zip_code:'',
+        mail_street_address:'', mail_apt_num:'', mail_city:'', mail_state:'', mail_zip_code:'',
         id_number:'', id_issue_date_month:'', id_issue_date_day:'', id_issue_date_year:'', id_expire_date_month:'', id_expire_date_day:'', id_expire_date_year:'',
         party_choice:'',
         email_address:'', sms_alert_phone_number:''});
         const [hasData, setHasData] = useState(false)
 
     const saveFieldData = (name) => {
-
         return (event) => {
             event.target.value.length > 0 && setHasData(true)
             if (name === 'phone_number') {
@@ -112,29 +111,49 @@ function MultiStepForm(props) {
     const [previousName, setPreviousName] = useState(false);
     const onChangePreviousName = (e) => {
         setPreviousName(e.target.checked);
+        //clear prev name form data when box is unchecked
+        !e.target.checked && setFieldData({
+            ...fieldData,
+            prev_title:'', prev_first_name: '', prev_middle_name: '', prev_last_name: '', prev_suffix:'',
+        })
     }
 
         //Addresses
-    const [hasNoAddress, setHasNoAddress] = useState(false);
+    const [hasNoAddress, setHasNoAddress] = useState(false);    
+    const [hasMailAddress, setHasMailAddress] = useState(false);
+    const onChangeMailAddressCheckbox = (e) => {
+        setHasMailAddress(e.target.checked);
+        !e.target.checked && setFieldData({
+            ...fieldData,
+            mail_street_address:'', mail_apt_num:'', mail_city:'', mail_state:'', mail_zip_code:''
+        })
+    }
+
     const hasNoAddressCheckbox = (e) => {
         setHasNoAddress(e.target.checked);
-        //clear any address form data when check is true
-        e.target.checked && setFieldData({
+        setFieldData({
             ...fieldData,
-            street_address:'', apt_num:'', city:'', state:'', zip_code:'',
-            prev_address_check: false, prev_street_address:'', prev_apt_num:'', prev_city:'', prev_state:'', prev_zip_code:'',
-            mail_address_check: false, mail_street_address:'', mail_apt_num:'', mail_city:'', mail_state:'', mail_zip_code:''
+            street_address:'', apt_num:'', city:'', state:'', zip_code:''
         })
+
+        if (!e.target.checked && document.getElementById("alt-mail-addr")) {
+            if (!hasMailAddress) {
+                setFieldData({
+                    ...fieldData,
+                    mail_street_address:'', mail_apt_num:'', mail_city:'', mail_state:'', mail_zip_code:''
+                })                
+            }
+
+        }
     }
 
     const [hasPreviousAddress, setHasPreviousAddress] = useState(false);
     const onChangePreviousAddressCheckbox = (e) => {
         setHasPreviousAddress(e.target.checked);
-    }
-
-    const [hasMailAddress, setHasMailAddress] = useState(false);
-    const onChangeMailAddressCheckbox = (e) => {
-        setHasMailAddress(e.target.checked);
+        !e.target.checked && setFieldData({
+            ...fieldData,
+            prev_street_address:'', prev_apt_num:'', prev_city:'', prev_state:'', prev_zip_code:''
+        })
     }
 
         //Identification


### PR DESCRIPTION
[VOTE-529](https://cm-jira.usa.gov/browse/VOTE-529)

To test fill out the different address types in different combinations using the checkboxes to hide/show fields and confirm they are displaying correctly on the confirmation page. example: previous + current, previous + mailing, mailing, current, etc..