### PR TITLE
VOTE-575: Remove default state from current address section of confirm/pdf 

### DIFF
--- a/src/components/FormSections/Confirmation.jsx
+++ b/src/components/FormSections/Confirmation.jsx
@@ -94,7 +94,7 @@ function Confirmation(props){
                         <li>Street Address: {fieldData.street_address}</li>
                         <li>Apt. or Lot #: {fieldData.apt_num}</li>
                         <li>City: {fieldData.city}</li>
-                        <li>State: {fieldDataOverride_state}</li>
+                        <li>State: {currentAddress && fieldDataOverride_state}</li>
                         <li>Zip code: {fieldData.zip_code}</li>
                     </ul>
 

--- a/src/components/GenerateFilledPDF.jsx
+++ b/src/components/GenerateFilledPDF.jsx
@@ -1,5 +1,4 @@
 import { PDFDocument} from 'pdf-lib';
-import download from "downloadjs";
 
 const GenerateFilledPDF = async function (formData,pagesKept) {
     // Fetch the PDF with form fields
@@ -123,11 +122,16 @@ const GenerateFilledPDF = async function (formData,pagesKept) {
 
     //(2) Addresses
     //Home
+    const currentAddress = formData.street_address + formData.apt_num + formData.city + formData.zip_code;
+    //check if anything other than default state selection is filled out
+    if (currentAddress) {
     homeAddress.setText(formData.street_address);
     aptNumber.setText(formData.apt_num);
     city.setText(formData.city);
     state.setText(formData.state);
-    zipcode.setText(formData.zip_code);
+    zipcode.setText(formData.zip_code);        
+    }
+
     //Mail
     mailAddress.setText(`${formData.mail_street_address} ${formData.mail_apt_num}`);
     mailCity.setText(formData.mail_city);


### PR DESCRIPTION
Test by filling out any address data OTHER THAN current address. Confirm the selected state is not included under "current address" section of confirm page or filled in on the pdf. Test that it does show when current address is filled out.