### PR TITLE
Vote-571: Fix Date of Birth to accept `10`

### DIFF
--- a/src/components/FormSections/PersonalInfo.jsx
+++ b/src/components/FormSections/PersonalInfo.jsx
@@ -194,7 +194,7 @@ function PersonalInfo(props){
                                     unit="month"
                                     required={true}
                                     type="text"
-                                    pattern="0[1-9]|1[1,2]"
+                                    pattern="0[1-9]|1[0,1,2]"
                                     inputMode="numeric"
                                     maxLength={2}
                                     minLength={2}


### PR DESCRIPTION
Ticket - [Vote-571](https://cm-jira.usa.gov/browse/VOTE-571)
Purpose - Adding `0` in the accepted numbers that can be accepted in the date of birth fields 
Testing:
1. Visit [preview link]() and select `Alaska` and navigate to the Personal Information Page and fill out all the fields. 
2. For date of birth add `10, 10, 2000` and ensure that you are able to move forward