### PR TITLE
VOTE-674/political party special case

### DIFF
--- a/public/data/en/states.json
+++ b/public/data/en/states.json
@@ -16,6 +16,7 @@
     "registration_url": "https://www.alabamainteractive.org/sos/voter_registration/voterRegistrationWelcome.action",
     "election_website_url": "https://www.sos.alabama.gov/alabama-votes",
     "more_info_url": "https://www.sos.alabama.gov/alabama-votes/voter/register-to-vote",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://myinfo.alabamavotes.gov/VoterView/RegistrantSearch.do",
     "postmarked_mail_deadline": "Must be postmarked 15 days before Election Day",
     "received_mail_deadline": "",
@@ -169,8 +170,8 @@
     "registration_url": "https://voterregistration.alaska.gov/",
     "election_website_url": "https://www.elections.alaska.gov/",
     "more_info_url": "https://www.elections.alaska.gov/Core/voterregistration.php",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://myvoterinformation.alaska.gov/",
-    "mail_reg_url": "https://www.elections.alaska.gov/doc/forms/C03.pdf",
     "postmarked_mail_deadline": "Must be postmarked 30 days before Election Day",
     "received_mail_deadline": "",
     "nvrf_fields": [
@@ -304,7 +305,7 @@
     }
     ],
     "nvrf_last_updated_date": "<time datetime=\"2006-03-01T12:00:00Z\">March 01, 2006</time>",
-    "nvrf_pages_list": "0,1,2,3,4,7"
+    "nvrf_pages_list": ""
     },
     {
     "uuid": "7c0f8267-931b-4cb8-b307-4362744bf896",
@@ -323,6 +324,7 @@
     "registration_url": "",
     "election_website_url": "https://aselectionoffice.gov/",
     "more_info_url": "https://aselectionoffice.gov/node/3",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://aselectionoffice.gov/status.php",
     "postmarked_mail_deadline": "",
     "received_mail_deadline": "Must be received 29 days before Election Day",
@@ -476,6 +478,7 @@
     "registration_url": "https://servicearizona.com/VoterRegistration/selectLanguage",
     "election_website_url": "https://azsos.gov/elections",
     "more_info_url": "https://azsos.gov/elections/voting-election/register-vote-or-update-your-current-voter-information",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://my.arizona.vote/WhereToVote.aspx?s=individual",
     "postmarked_mail_deadline": "Must be postmarked 29 days before Election Day",
     "received_mail_deadline": "",
@@ -625,6 +628,7 @@
     "registration_url": "",
     "election_website_url": "https://www.sos.arkansas.gov/elections/",
     "more_info_url": "https://www.sos.arkansas.gov/elections/voter-information/",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://www.voterview.ar-nova.org/voterview",
     "postmarked_mail_deadline": "Must be postmarked 30 days before Election Day",
     "received_mail_deadline": "",
@@ -774,6 +778,7 @@
     "registration_url": "https://registertovote.ca.gov/",
     "election_website_url": "https://www.sos.ca.gov/elections",
     "more_info_url": "https://www.sos.ca.gov/elections/voting-resources/voting-california/registering-vote",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://voterstatus.sos.ca.gov/",
     "postmarked_mail_deadline": "Must be postmarked 15 days before Election Day",
     "received_mail_deadline": "",
@@ -923,6 +928,7 @@
     "registration_url": "https://www.sos.state.co.us/voter/pages/pub/olvr/verifyNewVoter.xhtml",
     "election_website_url": "https://www.sos.state.co.us/pubs/elections/",
     "more_info_url": "https://www.coloradosos.gov/voter/pages/pub/home.xhtml",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://www.sos.state.co.us/voter/pages/pub/olvr/findVoterReg.xhtml",
     "postmarked_mail_deadline": "Must be postmarked 8 days before Election Day",
     "received_mail_deadline": "",
@@ -1072,6 +1078,7 @@
     "registration_url": "https://voterregistration.ct.gov/OLVR/welcome.do",
     "election_website_url": "https://portal.ct.gov/sots",
     "more_info_url": "https://portal.ct.gov/SOTS/Election-Services/Voter-Information/Voter-Fact-Sheet",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://portaldir.ct.gov/sots/LookUp.aspx",
     "postmarked_mail_deadline": "Must be postmarked 7 days before Election Day",
     "received_mail_deadline": "",
@@ -1185,10 +1192,6 @@
     "required": "1"
     },
     {
-    "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
-    "required": "1"
-    },
-    {
     "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
     "required": "1"
     },
@@ -1221,6 +1224,7 @@
     "registration_url": "https://ivote.de.gov/VoterView/registrant/newregistrant",
     "election_website_url": "https://elections.delaware.gov/index.shtml",
     "more_info_url": "https://elections.delaware.gov/voter/votereg.shtml",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://ivote.de.gov/VoterView",
     "postmarked_mail_deadline": "Must be postmarked 24 days before Election Day",
     "received_mail_deadline": "",
@@ -1369,8 +1373,9 @@
     "political_party_inst": "<p>You must register with a party if you want to take part in that party’s primary election, caucus, or convention.</p>",
     "registration_url": "https://vr.dcboe.org/213324797239968?agency_code=12",
     "election_website_url": "https://dcboe.org/",
-    "more_info_url": "https://www.dcboe.org/Voters/Register-To-Vote/Register-to-Vote",
-    "confirm_reg_url": "https://dcboe.org/Voters/Register-To-Vote/Check-Voter-Registration-Status",
+    "more_info_url": "https://www.dcboe.org/voters/register-to-vote/register-update-voter-registration",
+    "mail_reg_url": "",
+    "confirm_reg_url": "https://vr.dcboe.org/213324797239968?agency_code=12",
     "postmarked_mail_deadline": "",
     "received_mail_deadline": "Must be received 21 days before Election Day",
     "nvrf_fields": [
@@ -1487,10 +1492,6 @@
     "required": "1"
     },
     {
-    "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
-    "required": "1"
-    },
-    {
     "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
     "required": "1"
     },
@@ -1523,6 +1524,7 @@
     "registration_url": "https://registertovoteflorida.gov/eligibilityreactive",
     "election_website_url": "https://dos.myflorida.com/elections/",
     "more_info_url": "https://registertovoteflorida.gov/home",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://registration.elections.myflorida.com/CheckVoterStatus",
     "postmarked_mail_deadline": "Must be postmarked 29 days before Election Day",
     "received_mail_deadline": "",
@@ -1676,6 +1678,7 @@
     "registration_url": "https://registertovote.sos.ga.gov/GAOLVR/welcome.do#no-back-button",
     "election_website_url": "https://sos.ga.gov/index.php/elections",
     "more_info_url": "https://sos.ga.gov/elections-division-georgia-secretary-states-office",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://mvp.sos.ga.gov/s/",
     "postmarked_mail_deadline": "Must be postmarked 29 days before Election Day",
     "received_mail_deadline": "",
@@ -1829,6 +1832,7 @@
     "registration_url": "https://gec.guam.gov/register/",
     "election_website_url": "https://gec.guam.gov/",
     "more_info_url": "https://gec.guam.gov/",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://gec.guam.gov/validate/",
     "postmarked_mail_deadline": "",
     "received_mail_deadline": "Must be received 11 business days before Election Day",
@@ -1982,6 +1986,7 @@
     "registration_url": "https://olvr.hawaii.gov/",
     "election_website_url": "https://elections.hawaii.gov/",
     "more_info_url": "https://elections.hawaii.gov/voters/registration/",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://olvr.hawaii.gov/",
     "postmarked_mail_deadline": "Must be postmarked 8 days before Election Day",
     "received_mail_deadline": "",
@@ -2135,6 +2140,7 @@
     "registration_url": "https://elections.sos.idaho.gov/ElectionLink/ElectionLink/ApplicationInstructions.aspx",
     "election_website_url": "https://idahovotes.gov/",
     "more_info_url": "https://idahovotes.gov/voting/",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://elections.sos.idaho.gov/ElectionLink/ElectionLink/VoterSearch.aspx",
     "postmarked_mail_deadline": "Must be postmarked 25 days before Election Day",
     "received_mail_deadline": "",
@@ -2284,6 +2290,7 @@
     "registration_url": "https://ova.elections.il.gov/",
     "election_website_url": "https://www.elections.il.gov/",
     "more_info_url": "https://www.elections.il.gov/Default.aspx",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://ova.elections.il.gov/RegistrationLookup.aspx",
     "postmarked_mail_deadline": "Must be postmarked 28 days before Election Day",
     "received_mail_deadline": "",
@@ -2429,10 +2436,11 @@
     "id_inst": "<p>Your state voter ID number is your ten digit Indiana issued driver's license number. If you do not possess an Indiana driver's license then provide the last four digits of your social security number. Please indicate which number was provided. (Indiana Code 3-7-13-13)</p>",
     "address_inst": "",
     "personal_info_inst": "",
-    "political_party_inst": "",
+    "political_party_inst": "<p>Indiana does not accept political party information on this form.</p>",
     "registration_url": "https://indianavoters.in.gov/",
     "election_website_url": "https://www.in.gov/sos/elections/",
     "more_info_url": "https://www.in.gov/sos/elections/2403.htm",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://indianavoters.in.gov/",
     "postmarked_mail_deadline": "Must be postmarked 29 days before Election Day",
     "received_mail_deadline": "",
@@ -2546,10 +2554,6 @@
     "required": "1"
     },
     {
-    "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
-    "required": "1"
-    },
-    {
     "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
     "required": "1"
     },
@@ -2578,6 +2582,7 @@
     "registration_url": "https://mymvd.iowadot.gov/Account/Login?ReturnUrl=%2fVoterRegistration",
     "election_website_url": "https://sos.iowa.gov/",
     "more_info_url": "https://sos.iowa.gov/elections/voterinformation/voterregistration.html",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://sos.iowa.gov/elections/voterreg/regtovote/search.aspx",
     "postmarked_mail_deadline": "Must be postmarked 15 days before Election Day",
     "received_mail_deadline": "",
@@ -2727,6 +2732,7 @@
     "registration_url": "https://www.kdor.ks.gov/Apps/VoterReg/Default.aspx",
     "election_website_url": "https://sos.ks.gov/elections/elections.html",
     "more_info_url": "https://sos.ks.gov/elections/voter-information.html",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://myvoteinfo.voteks.org/voterview/",
     "postmarked_mail_deadline": "Must be postmarked 21 days before Election Day",
     "received_mail_deadline": "",
@@ -2876,6 +2882,7 @@
     "registration_url": "https://vrsws.sos.ky.gov/ovrweb/",
     "election_website_url": "https://elect.ky.gov/Pages/default.aspx",
     "more_info_url": "https://elect.ky.gov/Resources/Pages/Registration.aspx",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://vrsws.sos.ky.gov/VIC/",
     "postmarked_mail_deadline": "Must be postmarked 29 days before Election Day",
     "received_mail_deadline": "",
@@ -2985,14 +2992,6 @@
     "required": "1"
     },
     {
-    "uuid": "acd7f272-7a37-43f0-b51a-c78daf31e5fd",
-    "required": "1"
-    },
-    {
-    "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
-    "required": "1"
-    },
-    {
     "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
     "required": "1"
     },
@@ -3025,6 +3024,7 @@
     "registration_url": "https://voterportal.sos.la.gov/VoterRegistration",
     "election_website_url": "https://www.sos.la.gov/ElectionsAndVoting/Pages/default.aspx",
     "more_info_url": "https://www.sos.la.gov/ElectionsAndVoting/RegisterToVote/Pages/default.aspx",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://voterportal.sos.la.gov/",
     "postmarked_mail_deadline": "Must be postmarked 30 days before Election Day",
     "received_mail_deadline": "",
@@ -3169,7 +3169,7 @@
     "is_state": "1",
     "reg_type": "by-mail",
     "accepts_nvrf": "1",
-    "mailing_address_inst": "<p>Elections Division Bureau of Corporations, Elections and Commissions <br />101 State House Station <br />Augusta, ME 04333-0101</p><p>Municipal addresses: To meet registration deadlines, especially in the two weeks before the closed period (three weeks before an election) you should return the completed voter registration application directly to your municipal clerk. A complete list of municipal clerks is available at <a href=\"https://www. maine.gov/sos/cec/elec/\">https://www. maine.gov/sos/cec/elec/</a>.</p>",
+    "mailing_address_inst": "<p>Elections Division Bureau of Corporations, Elections and Commissions <br />101 State House Station <br />Augusta, ME 04333-0101</p><p>Municipal addresses: To meet registration deadlines, especially in the two weeks before the closed period (three weeks before an election) you should return the completed voter registration application directly to your municipal clerk. A complete list of municipal clerks is available at <a href=\"https://www.maine.gov/sos/cec/elec/munic.html\">https://www.maine.gov/sos/cec/elec/munic.html</a>.</p>",
     "reg_eligibility_desc": "<p>To register in Maine you must:  </p><ul><li>Be a citizen of the United States  </li><li>Be a resident of Maine and the municipality in which you want to vote</li><li>Be at least 16 years old (you must  be 18 years old to vote, or 17 years old for a Primary Election in which you will be 18 years old by that General Election) </li></ul>",
     "id_inst": "<p>You must list your valid Maine driver’s license number. If you don’t have a valid Maine driver’s license, then you must provide the last four digits of your Social Security Number. Voters who don’t have either of these forms of ID must select “I do not have a valid ID” on this form.</p>",
     "address_inst": "",
@@ -3178,8 +3178,8 @@
     "registration_url": "",
     "election_website_url": "https://www.maine.gov/sos/cec/elec/",
     "more_info_url": "https://www.maine.gov/sos/cec/elec/voter-info/voterguide.html",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://www.maine.gov/sos/cec/elec/data/index.html",
-    "mail_reg_url": "https://www.maine.gov/sos/cec/elec/upcoming/pdf/voterregcard20.pdf",
     "postmarked_mail_deadline": "",
     "received_mail_deadline": "Must be received 21 days before Election Day",
     "nvrf_fields": [
@@ -3292,10 +3292,6 @@
     "required": "1"
     },
     {
-    "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
-    "required": "1"
-    },
-    {
     "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
     "required": "1"
     },
@@ -3328,6 +3324,7 @@
     "registration_url": "https://voterservices.elections.maryland.gov/OnlineVoterRegistration/InstructionsStep1",
     "election_website_url": "https://elections.maryland.gov/",
     "more_info_url": "https://www.elections.maryland.gov/voter_registration/application.html",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://voterservices.elections.maryland.gov/VoterSearch",
     "postmarked_mail_deadline": "Must be postmarked 21 days before Election Day",
     "received_mail_deadline": "",
@@ -3477,6 +3474,7 @@
     "registration_url": "https://www.sec.state.ma.us/ovr/",
     "election_website_url": "https://www.sec.state.ma.us/ele/eleidx.htm",
     "more_info_url": "https://www.sec.state.ma.us/divisions/elections/voter-resources/registering-to-vote.htm",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://www.sec.state.ma.us/VoterRegistrationSearch/MyVoterRegStatus.aspx",
     "postmarked_mail_deadline": "Must be postmarked 10 days before Election Day",
     "received_mail_deadline": "",
@@ -3590,10 +3588,6 @@
     "required": "1"
     },
     {
-    "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
-    "required": "1"
-    },
-    {
     "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
     "required": "1"
     },
@@ -3626,6 +3620,7 @@
     "registration_url": "https://mvic.sos.state.mi.us/registervoter",
     "election_website_url": "https://www.michigan.gov/sos/elections",
     "more_info_url": "https://mvic.sos.state.mi.us/",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://mvic.sos.state.mi.us/Voter/Index",
     "postmarked_mail_deadline": "Must be postmarked 15 days before Election Day",
     "received_mail_deadline": "",
@@ -3771,10 +3766,11 @@
     "id_inst": "<p>You are required to provide your Minnesota driver’s license or state ID number to register to Vote. If you do not have a Minnesota driver’s license or state ID then you will have to provide the last four digits of your social security number. If you have neither, please select “I do not have a valid ID” on the form. </p>",
     "address_inst": "",
     "personal_info_inst": "",
-    "political_party_inst": "",
+    "political_party_inst": "<p>Minnesota does not accept political party information on this form.</p>",
     "registration_url": "https://mnvotes.sos.state.mn.us/VoterRegistration/VoterRegistrationMain.aspx",
     "election_website_url": "https://www.sos.state.mn.us/elections-voting/",
     "more_info_url": "https://www.sos.state.mn.us/elections-voting/register-to-vote/",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://mnvotes.sos.state.mn.us/VoterStatus.aspx",
     "postmarked_mail_deadline": "",
     "received_mail_deadline": "Must be received 21 days before Election Day",
@@ -3920,6 +3916,7 @@
     "registration_url": "",
     "election_website_url": "https://www.sos.ms.gov/elections-voting/voter-registration-information",
     "more_info_url": "https://www.sos.ms.gov/elections-voting/voter-registration-information",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://www.msegov.com/sos/voter_registration/amiregistered/Search",
     "postmarked_mail_deadline": "Must be postmarked 30 days before Election Day",
     "received_mail_deadline": "",
@@ -4033,10 +4030,6 @@
     "required": "1"
     },
     {
-    "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
-    "required": "1"
-    },
-    {
     "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
     "required": "1"
     },
@@ -4069,6 +4062,7 @@
     "registration_url": "https://s1.sos.mo.gov/elections/voterregistration/",
     "election_website_url": "https://www.sos.mo.gov/elections",
     "more_info_url": "https://www.sos.mo.gov/elections/goVoteMissouri/register",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://mvic.sos.state.mi.us/Voter/Index",
     "postmarked_mail_deadline": "Must be postmarked 27 days before Election Day",
     "received_mail_deadline": "",
@@ -4218,6 +4212,7 @@
     "registration_url": "",
     "election_website_url": "https://sosmt.gov/elections/",
     "more_info_url": "https://sosmt.gov/elections/vote/",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://prodvoterportal.mt.gov/WhereToVote.aspx",
     "postmarked_mail_deadline": "Must be postmarked 30 days before Election Day",
     "received_mail_deadline": "",
@@ -4367,6 +4362,7 @@
     "registration_url": "https://www.nebraska.gov/apps-sos-voter-registration/",
     "election_website_url": "https://sos.nebraska.gov/elections/2020-elections",
     "more_info_url": "https://sos.nebraska.gov/elections/voter-forms",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://www.votercheck.necvr.ne.gov/voterview",
     "postmarked_mail_deadline": "Must be postmarked 18 days before Election Day",
     "received_mail_deadline": "",
@@ -4480,10 +4476,6 @@
     "required": "1"
     },
     {
-    "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
-    "required": "1"
-    },
-    {
     "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
     "required": "1"
     },
@@ -4516,6 +4508,7 @@
     "registration_url": "https://www.nvsos.gov/SOSVoterServices/start.aspx",
     "election_website_url": "https://www.nvsos.gov/sos/elections",
     "more_info_url": "https://www.nvsos.gov/sos/elections/voters/registering-to-vote",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://www.nvsos.gov/votersearch/",
     "postmarked_mail_deadline": "Must be postmarked 28 days before Election Day",
     "received_mail_deadline": "",
@@ -4665,6 +4658,7 @@
     "registration_url": "",
     "election_website_url": "https://sos.nh.gov/home",
     "more_info_url": "https://www.sos.nh.gov/elections/voters/register-vote",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://app.sos.nh.gov/voterinformation",
     "postmarked_mail_deadline": "",
     "received_mail_deadline": "Must be received 13 days before Election Day",
@@ -4818,6 +4812,7 @@
     "registration_url": "https://voter.svrs.nj.gov/register",
     "election_website_url": "https://www.state.nj.us/state/elections/index.shtml",
     "more_info_url": "https://nj.gov/state/elections/voter-registration.shtml",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://voter.svrs.nj.gov/registration-check",
     "postmarked_mail_deadline": "",
     "received_mail_deadline": "Must be received 21 days before Election Day",
@@ -4931,10 +4926,6 @@
     "required": "1"
     },
     {
-    "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
-    "required": "1"
-    },
-    {
     "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
     "required": "1"
     },
@@ -4963,6 +4954,7 @@
     "registration_url": "https://portal.sos.state.nm.us/OVR/WebPages/InstructionsStep1.aspx",
     "election_website_url": "https://www.sos.state.nm.us/voting-and-elections/",
     "more_info_url": "https://www.sos.state.nm.us/voting-and-elections/voter-information/voter-registration-information/",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://voterportal.servis.sos.state.nm.us/WhereToVote.aspx",
     "postmarked_mail_deadline": "Must be postmarked 28 days before Election Day",
     "received_mail_deadline": "",
@@ -5072,14 +5064,6 @@
     "required": "1"
     },
     {
-    "uuid": "acd7f272-7a37-43f0-b51a-c78daf31e5fd",
-    "required": "1"
-    },
-    {
-    "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
-    "required": "1"
-    },
-    {
     "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
     "required": "1"
     },
@@ -5112,6 +5096,7 @@
     "registration_url": "https://dmv.ny.gov/more-info/electronic-voter-registration-application",
     "election_website_url": "https://www.elections.ny.gov/",
     "more_info_url": "https://www.elections.ny.gov/votingregister.html",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://voterlookup.elections.ny.gov/",
     "postmarked_mail_deadline": "",
     "received_mail_deadline": "Must be received 10 days before Election Day",
@@ -5225,10 +5210,6 @@
     "required": "1"
     },
     {
-    "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
-    "required": "1"
-    },
-    {
     "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
     "required": "1"
     },
@@ -5261,6 +5242,7 @@
     "registration_url": "https://www.ncdot.gov/dmv/offices-services/online/Pages/voter-registration-application.aspx",
     "election_website_url": "https://www.ncsbe.gov/voting",
     "more_info_url": "https://www.ncsbe.gov/registering/how-register",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://vt.ncsbe.gov/RegLkup/",
     "postmarked_mail_deadline": "Must be postmarked 25 days before Election Day",
     "received_mail_deadline": "",
@@ -5414,6 +5396,7 @@
     "registration_url": "",
     "election_website_url": "https://vip.sos.nd.gov/PortalList.aspx",
     "more_info_url": "https://vip.sos.nd.gov/PortalList.aspx",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://vip.sos.nd.gov/WhereToVote.aspx?tab=&amp;amp;ptlPKID=&amp;amp;ptlhPKID=",
     "postmarked_mail_deadline": "",
     "received_mail_deadline": "",
@@ -5567,6 +5550,7 @@
     "registration_url": "",
     "election_website_url": "https://www.votecnmi.gov.mp/",
     "more_info_url": "https://www.votecnmi.gov.mp/",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://www.votecnmi.gov.mp/voter/are-you-registered-to-vote",
     "postmarked_mail_deadline": "",
     "received_mail_deadline": "",
@@ -5720,6 +5704,7 @@
     "registration_url": "https://olvr.ohiosos.gov/",
     "election_website_url": "https://www.sos.state.oh.us/elections/",
     "more_info_url": "https://olvr.ohiosos.gov/",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://voterlookup.ohiosos.gov/voterlookup.aspx",
     "postmarked_mail_deadline": "Must be postmarked 30 days before Election Day",
     "received_mail_deadline": "",
@@ -5869,6 +5854,7 @@
     "registration_url": "",
     "election_website_url": "https://www.ok.gov/elections/",
     "more_info_url": "https://oklahoma.gov/elections/voter-registration/register-to-vote.html",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://okvoterportal.okelections.us/",
     "postmarked_mail_deadline": "Must be postmarked 25 days before Election Day",
     "received_mail_deadline": "",
@@ -6018,6 +6004,7 @@
     "registration_url": "https://secure.sos.state.or.us/orestar/vr/register.do",
     "election_website_url": "https://sos.oregon.gov/voting-elections/Pages/default.aspx",
     "more_info_url": "https://sos.oregon.gov/voting/Pages/registration.aspx",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://secure.sos.state.or.us/orestar/vr/showVoterSearch.do?lang=eng&amp;amp;source=SOS",
     "postmarked_mail_deadline": "Must be postmarked 21 days before Election Day",
     "received_mail_deadline": "",
@@ -6167,6 +6154,7 @@
     "registration_url": "https://www.pavoterservices.pa.gov/Pages/VoterRegistrationApplication.aspx",
     "election_website_url": "https://www.pa.gov/guides/voting-and-elections/",
     "more_info_url": "https://www.pa.gov/guides/voting-and-elections/#RegisteringtoVote",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://www.pavoterservices.pa.gov/pages/voterregistrationstatus.aspx",
     "postmarked_mail_deadline": "",
     "received_mail_deadline": "Must be received 15 days before Election Day",
@@ -6284,10 +6272,6 @@
     "required": "1"
     },
     {
-    "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
-    "required": "1"
-    },
-    {
     "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
     "required": "1"
     },
@@ -6320,6 +6304,7 @@
     "registration_url": "",
     "election_website_url": "https://ww2.ceepur.org/Home/Index?aspxerrorpath=/es-pr/Paginas/default.aspx",
     "more_info_url": "https://ww2.ceepur.org/es-pr/Paginas/cee-english.aspx",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://consulta.ceepur.org/",
     "postmarked_mail_deadline": "",
     "received_mail_deadline": "",
@@ -6473,6 +6458,7 @@
     "registration_url": "https://vote.sos.ri.gov/Home/RegistertoVote",
     "election_website_url": "https://elections.ri.gov/",
     "more_info_url": "https://vote.sos.ri.gov/Voter/RegisterToVote",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://vote.sos.ri.gov/Home/UpdateVoterRecord?ActiveFlag=0",
     "postmarked_mail_deadline": "Must be postmarked 30 days before Election Day",
     "received_mail_deadline": "",
@@ -6622,6 +6608,7 @@
     "registration_url": "https://info.scvotes.sc.gov/eng/ovr/start.aspx",
     "election_website_url": "https://www.scvotes.gov/",
     "more_info_url": "https://scvotes.gov/voters/register-to-vote/",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://info.scvotes.sc.gov/eng/voterinquiry/VoterInformationRequest.aspx?PageMode=VoterInfo",
     "postmarked_mail_deadline": "Must be postmarked 30 days before Election Day",
     "received_mail_deadline": "",
@@ -6735,14 +6722,6 @@
     "required": "1"
     },
     {
-    "uuid": "acd7f272-7a37-43f0-b51a-c78daf31e5fd",
-    "required": "1"
-    },
-    {
-    "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
-    "required": "1"
-    },
-    {
     "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
     "required": "1"
     },
@@ -6775,6 +6754,7 @@
     "registration_url": "",
     "election_website_url": "https://sdsos.gov/elections-voting/",
     "more_info_url": "https://sdsos.gov/elections-voting/voting/register-to-vote/default.aspx",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://vip.sdsos.gov/VIPLogin.aspx",
     "postmarked_mail_deadline": "",
     "received_mail_deadline": "Must be received 15 days before Election Day",
@@ -6924,6 +6904,7 @@
     "registration_url": "https://ovr.govote.tn.gov/",
     "election_website_url": "https://sos.tn.gov/elections",
     "more_info_url": "https://sos.tn.gov/products/elections/register-vote",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://tnmap.tn.gov/voterlookup/",
     "postmarked_mail_deadline": "Must be postmarked 30 days before Election Day",
     "received_mail_deadline": "",
@@ -7037,14 +7018,6 @@
     "required": "1"
     },
     {
-    "uuid": "acd7f272-7a37-43f0-b51a-c78daf31e5fd",
-    "required": "1"
-    },
-    {
-    "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
-    "required": "1"
-    },
-    {
     "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
     "required": "1"
     },
@@ -7077,6 +7050,7 @@
     "registration_url": "",
     "election_website_url": "https://www.votetexas.gov/index.html",
     "more_info_url": "https://www.votetexas.gov/register-to-vote/index.html",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://teamrv-mvp.sos.texas.gov/MVP/mvp.do",
     "postmarked_mail_deadline": "Must be postmarked 30 days before Election Day",
     "received_mail_deadline": "",
@@ -7190,10 +7164,6 @@
     "required": "1"
     },
     {
-    "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
-    "required": "1"
-    },
-    {
     "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
     "required": "1"
     },
@@ -7226,6 +7196,7 @@
     "registration_url": "",
     "election_website_url": "https://vivote.gov/voters/register-to-vote/",
     "more_info_url": "https://vivote.gov/voters/register-to-vote/",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://vivote.gov/voters/lookup/",
     "postmarked_mail_deadline": "",
     "received_mail_deadline": "",
@@ -7379,6 +7350,7 @@
     "registration_url": "https://secure.utah.gov/voterreg/login.html?selection=REGISTER",
     "election_website_url": "https://elections.utah.gov/",
     "more_info_url": "https://voteinfo.utah.gov/",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://votesearch.utah.gov/voter-search/search/search-by-voter/voter-info",
     "postmarked_mail_deadline": "",
     "received_mail_deadline": "Must be received 11 days before Election Day",
@@ -7528,6 +7500,7 @@
     "registration_url": "https://olvr.vermont.gov/",
     "election_website_url": "https://sos.vermont.gov/elections/",
     "more_info_url": "https://sos.vermont.gov/elections/voters/registration/",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://mvp.vermont.gov/",
     "postmarked_mail_deadline": "",
     "received_mail_deadline": "Must be received by or on Election Day",
@@ -7645,10 +7618,6 @@
     "required": "1"
     },
     {
-    "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
-    "required": "1"
-    },
-    {
     "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
     "required": "1"
     },
@@ -7677,10 +7646,11 @@
     "id_inst": "<p>Your full social security number is required. Your social security number will appear on reports produced only for official use by voter registration and election officials and, for jury selection purposes, by courts. Article II, §2, Constitution of Virginia (1971).</p>",
     "address_inst": "",
     "personal_info_inst": "",
-    "political_party_inst": "",
+    "political_party_inst": "<p>Virginia does not accept political party information on this form.</p>",
     "registration_url": "https://www.elections.virginia.gov/citizen-portal/",
     "election_website_url": "https://www.elections.virginia.gov/",
     "more_info_url": "https://www.elections.virginia.gov/registration/how-to-register/",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://www.elections.virginia.gov/registration/view-your-info/",
     "postmarked_mail_deadline": "Must be postmarked 22 days before Election Day",
     "received_mail_deadline": "",
@@ -7790,14 +7760,6 @@
     "required": "1"
     },
     {
-    "uuid": "acd7f272-7a37-43f0-b51a-c78daf31e5fd",
-    "required": "1"
-    },
-    {
-    "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
-    "required": "1"
-    },
-    {
     "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
     "required": "1"
     },
@@ -7826,6 +7788,7 @@
     "registration_url": "https://voter.votewa.gov/WhereToVote.aspx",
     "election_website_url": "https://www.sos.wa.gov/elections/",
     "more_info_url": "https://www.sos.wa.gov/elections/voters/",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://voter.votewa.gov/WhereToVote.aspx",
     "postmarked_mail_deadline": "",
     "received_mail_deadline": "Must be received 8 days before Election Day",
@@ -7975,6 +7938,7 @@
     "registration_url": "https://ovr.sos.wv.gov/Register/Landing",
     "election_website_url": "https://sos.wv.gov/elections/Pages/default.aspx",
     "more_info_url": "https://ovr.sos.wv.gov/Register/Landing",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://apps.sos.wv.gov/Elections/voter/amiregisteredtovote",
     "postmarked_mail_deadline": "Must be postmarked 21 days before Election Day",
     "received_mail_deadline": "",
@@ -8088,10 +8052,6 @@
     "required": "1"
     },
     {
-    "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
-    "required": "1"
-    },
-    {
     "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
     "required": "1"
     },
@@ -8124,6 +8084,7 @@
     "registration_url": "https://myvote.wi.gov/en-us/RegisterToVote",
     "election_website_url": "https://elections.wi.gov/voters",
     "more_info_url": "https://elections.wi.gov/Register",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://myvote.wi.gov/en-us/MyVoterInfo",
     "postmarked_mail_deadline": "Must be postmarked 20 days before Election Day",
     "received_mail_deadline": "",
@@ -8277,6 +8238,7 @@
     "registration_url": "",
     "election_website_url": "https://sos.wyo.gov/elections/state/registeringtovote.aspx",
     "more_info_url": "https://sos.wyo.gov/Elections/State/RegisteringToVote.aspx",
+    "mail_reg_url": "",
     "confirm_reg_url": "https://sos.wyo.gov/Elections/Docs/WYCountyClerks.pdf",
     "postmarked_mail_deadline": "",
     "received_mail_deadline": "Must be received 14 days before Election Day",

--- a/src/components/FormSections/Confirmation.jsx
+++ b/src/components/FormSections/Confirmation.jsx
@@ -13,7 +13,7 @@ function Confirmation(props) {
 
     //field data overrides for confirm page printing only
     const fieldDataOverride_race = (fieldData.race === '') ? "Not required for your state" : fieldData.race;
-    const fieldDataOverride_party = (fieldData.party_choice === '') ? "No party entered" : fieldData.party_choice;
+    const fieldDataOverride_party = (fieldData.party_choice === '') ? "Not required for your state" : fieldData.party_choice;
     const fieldDataOverride_state = props.stateData.name;
     fieldData.state = fieldDataOverride_state;
 

--- a/src/components/FormSections/PoliticalParty.jsx
+++ b/src/components/FormSections/PoliticalParty.jsx
@@ -24,9 +24,10 @@ function PoliticalParty(props){
     return (
         <>
         <h2>{headings.step_label_4}</h2>
+
         {(partyStateInstructions || partyGeneralInstructions) && (
         <div className="usa-alert usa-alert--info" role="alert">
-            <div className="usa-alert__body" dangerouslySetInnerHTML= {{__html: partyGeneralInstructions}}/>
+            {partyFieldState && (<div className="usa-alert__body" dangerouslySetInnerHTML= {{__html: partyGeneralInstructions}}/>)}
             <div className="usa-alert__body" dangerouslySetInnerHTML= {{__html: partyStateInstructions}}/>
         </div>)}
 


### PR DESCRIPTION
Jira Ticket: https://cm-jira.usa.gov/browse/VOTE-674

Description: In the case where a state does not accept a political party on the NVRF, only the state instructions display in the alert.

Testing:
1. Select Indiana
2. Confirm that the political party field box is hidden.
3. Confirm in the alert box that only the state specific instructions display (and not the general instructions).
4. On the confirmation page, confirm the text "Not required by your state" is next to the political party.
5. Go back and select Alaska
6. Confirm the above changes are not reflected in Alaska (for states where political party is required or the user put in a value to the optional field)