### PR TITLE
Vote:673 - Start Button Text Update

### DIFF
--- a/public/data/en/navigation.json
+++ b/public/data/en/navigation.json
@@ -13,7 +13,6 @@
     "next": {
         "next": "Next",
         "start": "I want to use vote.gov’s mail-in form",
-        "continue": "Start your online registration on vote.gov",
         "reg_options": "Continue to view registration options",
         "address_location": "Continue to address and location",
         "identification": "Continue to identification",

--- a/src/components/Eligibility.jsx
+++ b/src/components/Eligibility.jsx
@@ -65,7 +65,7 @@ function Eligibility(props) {
                 <div dangerouslySetInnerHTML= {{__html: eligibilityInstructions}}/>
 
                 <div className="button-container" style={{ margin:'20px' }}>
-                    <NextButton type={'submit'} onClick={() => props.checkboxValid()} text={navContent.next.continue}/>
+                    <NextButton type={'submit'} onClick={() => props.checkboxValid()} text={navContent.next.start}/>
                 </div>
             </form>
         </>

--- a/src/components/RegType/ByMail.jsx
+++ b/src/components/RegType/ByMail.jsx
@@ -43,7 +43,7 @@ function ByMail(props) {
 
             <div className={'usa-prose'} dangerouslySetInnerHTML= {{__html: contentBodyProcessed}}/>
 
-            <NextButton type={'submit'} onClick={props.handleNext} text={navContent.next.continue}/>
+            <NextButton type={'submit'} onClick={props.handleNext} text={navContent.next.start}/>
         </>
     );
 }


### PR DESCRIPTION
Purpose: This Pr will update the 'start' button to have the correct text of `I want to use vote.gov’s mail-in form` instead of the old `Start your online registration on vote.gov`
Ticket: [Vote-673](https://cm-jira.usa.gov/browse/VOTE-673)
Testing:

1. Visit [preview link](https://federalist-aef5b597-8e18-44b6-aeba-3fc3f17cdac1.sites.pages.cloud.gov/preview/usagov/vote-gov-nvrf-app/bug/vote-673-state-btn-udpate/) and visit the following states `Arkansas`, `Maine`, `Mississippi`, `Montana`, `New Hampshire`, `Oklahoma`, `South Dakota`, `Texas` and `Wyoming`
2. Check that the 'start' button on the first 2 pages have the correct text of `I want to use vote.gov’s mail-in form` 

See screen shot below for OLD reference

<img width="623" alt="Start button update vote 673" src="https://github.com/usagov/vote-gov-nvrf-app/assets/88721460/31d1815b-44bc-44ac-baf5-3b9498a8a835">
