### PR TITLE
Vote-685: Update to checkbox on personal info page 

### DIFF
--- a/src/components/FormSections/PersonalInfo.jsx
+++ b/src/components/FormSections/PersonalInfo.jsx
@@ -65,7 +65,7 @@ function PersonalInfo(props){
         <h2>{headings.step_label_1}</h2>
 
         {changeRegistrationVisible && (
-            <Checkbox id="prev-name-change" name="prev-name-change" checked={props.prevh2iousName} onChange={props.onChangePreviousName} label={"I have legally changed my name since I last registered in this state."} />
+            <Checkbox id="prev-name-change" name="prev-name-change" checked={props.previousName} onChange={props.onChangePreviousName} label={"I have legally changed my name since I last registered in this state."} />
         )}
 
         <div className="usa-alert usa-alert--info" role="alert">

--- a/src/components/MultiStepForm.jsx
+++ b/src/components/MultiStepForm.jsx
@@ -109,7 +109,7 @@ function MultiStepForm(props) {
 
     //Form Sections controls//
         //Personal Info
-    const [previousName, setPreviousName] = useState(false);
+    const [hasPreviousName, setPreviousName] = useState(false);
     const onChangePreviousName = (e) => {
         setPreviousName(e.target.checked);
         //clear prev name form data when box is unchecked
@@ -258,7 +258,7 @@ function MultiStepForm(props) {
                         saveFieldData = {saveFieldData}
                         dateFormat={dateFormat}
                         registrationPath={props.registrationPath}
-                        previousName={previousName}
+                        previousName={hasPreviousName}
                         onChangePreviousName={onChangePreviousName}
                         handlePrev={props.handlePrev}
                         headings={navContent}


### PR DESCRIPTION
Purpose:  This PR will update the checkbox on `name change` on Personal Info page to stay selected when the user leaves the page. 
Ticket: [Vote-685](https://cm-jira.usa.gov/browse/VOTE-685)
Testing:

1. Check [preview link]() and select a state
2. Make your way to the personal info page from the `change registration` option and select the name change option 
3. Move to next page and then go back to personal info page and ensure that checkbox is still selected 