### PR TITLE
Vote-729: Update to political page instructions

### DIFF
--- a/src/components/FormSections/PoliticalParty.jsx
+++ b/src/components/FormSections/PoliticalParty.jsx
@@ -27,34 +27,31 @@ function PoliticalParty(props){
 
         {(partyStateInstructions || partyGeneralInstructions) && (
         <div className="usa-alert usa-alert--info" role="alert">
-            {partyFieldState && (<div className="usa-alert__body" dangerouslySetInnerHTML= {{__html: partyGeneralInstructions}}/>)}
             <div className="usa-alert__body" dangerouslySetInnerHTML= {{__html: partyStateInstructions}}/>
         </div>)}
 
         {partyFieldState && (
-            <div className={(parseInt(partyFieldState.required) && handleErrors.party_choice) ? 'error-container margin-top-6' : 'margin-top-5'}>
-                <Label className="text-bold" htmlFor="political-party">
-                {partyField.name}{(partyFieldState.required === "1") && <span className='required-text'>*</span>}
-                <TextInput
-                    id="political-party"
-                    className="radius-md"
-                    aria-describedby="party-choice-error"
-                    name="political party"
-                    value={props.fieldData.party_choice}
-                    type="text"
-                    autoComplete="off"
-                    required={parseInt(partyFieldState.required)}
-                    onChange={props.saveFieldData('party_choice')}
-                    onKeyDown={(e) => restrictType(e, 'letters')}
-                    onBlur={(e) => setHandleErrors({ ...handleErrors, party_choice: checkForErrors(e, 'check value exists') })}
-                />
-                {((partyFieldState.required === "1") && handleErrors.party_choice) &&
-                    <span id="party-choice-error" role="alert" className='error-text'>
-                        {partyField.error_msg}
-                    </span>
-                }
-                </Label>
-            </div>
+            <><div className={(parseInt(partyFieldState.required) && handleErrors.party_choice) ? 'error-container margin-top-6' : 'margin-top-5'}>
+                    <Label className="text-bold" htmlFor="political-party">
+                        {partyField.name}{(partyFieldState.required === "1") && <span className='required-text'>*</span>}
+                        <TextInput
+                            id="political-party"
+                            className="radius-md"
+                            aria-describedby="party-choice-error"
+                            name="political party"
+                            value={props.fieldData.party_choice}
+                            type="text"
+                            autoComplete="off"
+                            required={parseInt(partyFieldState.required)}
+                            onChange={props.saveFieldData('party_choice')}
+                            onKeyDown={(e) => restrictType(e, 'letters')}
+                            onBlur={(e) => setHandleErrors({ ...handleErrors, party_choice: checkForErrors(e, 'check value exists') })} />
+                        {((partyFieldState.required === "1") && handleErrors.party_choice) &&
+                            <span id="party-choice-error" role="alert" className='error-text'>
+                                {partyField.error_msg}
+                            </span>}
+                    </Label>
+                </div><div dangerouslySetInnerHTML={{ __html: partyGeneralInstructions }} /></>
         )}
         </>
     );


### PR DESCRIPTION
Purpose: This PR will move the generic political party instructions to be out of the alert field and under the text box.. this text has also been updated in the CMS and will be new as well. 

Ticket: [Vote-729](https://cm-jira.usa.gov/browse/VOTE-729)

Testing:
- select a state and navigate to the political party... the expected result is that there is only one alert and then text below the text field 

Below is from Alabama 

Before:
 
<img width="568" alt="Screenshot 2024-01-22 at 8 47 06 PM" src="https://github.com/usagov/vote-gov-nvrf-app/assets/88721460/a2f1c0d0-51f7-4d9d-a524-418fd329611a">

After:

<img width="927" alt="Screenshot 2024-01-22 at 12 10 50 PM" src="https://github.com/usagov/vote-gov-nvrf-app/assets/88721460/0823227e-47cd-4e56-b1c2-136f2198eede">


