### PR TITLE
Vote-763: ID page fix

### DIFF
--- a/src/components/FormSections/Identification.jsx
+++ b/src/components/FormSections/Identification.jsx
@@ -31,8 +31,6 @@ function Identification(props){
     const [handleErrors, setHandleErrors] = useState({
         id_selection: false,
         id_number: false,
-        issue_date: false,
-        expire_date: false,
         id_ssn: false,
         id_none: false
     })

--- a/src/components/MultiStepForm.jsx
+++ b/src/components/MultiStepForm.jsx
@@ -166,21 +166,11 @@ function MultiStepForm(props) {
     const [idType, setIdType] = useState('')
     const saveIdType = (e) => {
         setIdType(e.target.value)
-        e.target.value === 'none' ?
-            setFieldData({
-                ...fieldData,
-                id_number: 'none',
-                ssn_number: '',
-                id_issue_date_month:'',
-                id_issue_date_day:'',
-                id_issue_date_year:'',
-                id_expire_date_month:'',
-                id_expire_date_day:'',
-                id_expire_date_year:''
-            })
-            :
-            setFieldData({ ...fieldData, id_number: '' });
-            setFieldData({ ...fieldData, ssn_number: '' });
+        setFieldData({
+            ...fieldData,
+            id_number: '',
+            ssn_number: '',
+        })
     }
     const [hasNoID, setHasNoID] = useState(false);
     const onChangeHasNoIdCheckbox = (e) => {


### PR DESCRIPTION
Ticket: [Vote-763](https://cm-jira.usa.gov/browse/VOTE-763)
Purpose: This Pr will fix the error where multiple inputs were rendering on the confirmation page. 
Testing:

1. Visit [preview link](https://federalist-aef5b597-8e18-44b6-aeba-3fc3f17cdac1.sites.pages.cloud.gov/preview/usagov/vote-gov-nvrf-app/bug/vote-763-id-page/) and select a state and navigate to the id page
2. Select each option and ensure that you can see that option on the conformation page. Once you have done that go back and select a new options with new numbers and check that the correct number is present and there is only one and not multiple. 
