### PR TITLE
HOTFIX: Updated "states online form" button string

### DIFF
--- a/src/components/RegType/Online.jsx
+++ b/src/components/RegType/Online.jsx
@@ -16,7 +16,7 @@ function Online(props) {
         const stateOnlineLink = () => (
                 <p>
                     <a href={stateContent.registration_url} className="usa-button" target="_blank">
-                        <span>{stringContent.stateName.replace("@state_name", stateContent.name)}</span>
+                        <span>{stringContent.stateOnlineName.replace("@state_name", stateContent.name)}</span>
                         <Icon.Launch title={stringContent.extlink} style={{margin: "-3px -3px -3px 4px"}}/>
                     </a>
                 </p>


### PR DESCRIPTION
Hot fix to address string after state selection to read "visit states on line form"

To text -> visit preview link and check that Alaska, Guam, Colorado and California read "visit states online form" in the first button after state selection 