### PR TITLE
VOTE-822 update circlci configuration for pulling the latest EAC PDF

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
       - run:
           name: Replace current NVRF
           command: |
+            cd vote-gov-nvrf-app
             artifacts=$(curl -X GET "https://circleci.com/api/v2/project/github/usagov/vote-gov-nvrf-app/$CIRCLE_BUILD_NUM/artifacts" \
             -H "Accept: application/json" \
             -u "$NVRF_PDF_WRITE:")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           name: git stuff
           command: | 
             GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone -b "update-nvrf-pdf" "$CIRCLE_REPOSITORY_URL"      
-            gh/install
+            # gh/install
             git config user.email "circleci@df52e93b2563.(none)"
             git config user.name "Pipeline Commit"
       #configure git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
       #checkout pdf branch and install gh
       # - run: git clone -b "update-nvrf-pdf" "$CIRCLE_REPOSITORY_URL"
+      - gh/install
       - run: 
           name: git stuff
           command: | 
             GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone -b "update-nvrf-pdf" "$CIRCLE_REPOSITORY_URL"
             cd vote-gov-nvrf-app
-            # gh/install
             git config user.email "circleci@df52e93b2563.(none)"
             git config user.name "Pipeline Commit"
       #configure git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,9 @@ jobs:
       - run: 
           name: git stuff
           command: | 
-            GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone -b "update-nvrf-pdf" "$CIRCLE_REPOSITORY_URL"      
+            GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone -b "update-nvrf-pdf" "$CIRCLE_REPOSITORY_URL"
+            pwd 
+            ls -l      
             # gh/install
             git config user.email "circleci@df52e93b2563.(none)"
             git config user.name "Pipeline Commit"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,10 +73,10 @@ workflows:
   update-nvrf-workflow:
     jobs:
       - update-nvrf
-    # triggers:
-    #   - schedule:
-    #       cron: '0 0 * * 5'
-    #       filters:
-    #         branches:
-    #           only:
-    #             - stage
+    triggers:
+      - schedule:
+          cron: '0 0 * * 5'
+          filters:
+            branches:
+              only:
+                - stage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,15 +12,20 @@ jobs:
     steps:
       #checkout pdf branch and install gh
       # - run: git clone -b "update-nvrf-pdf" "$CIRCLE_REPOSITORY_URL"
-      - run: GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone -b "update-nvrf-pdf" "$CIRCLE_REPOSITORY_URL"      
-      - gh/install
-      #configure git
-      - run:
-          name: Configure git
-          command: |
-            # ssh-keyscan github.com >> ~/.ssh/known_hosts
+      - run: 
+          name: git stuff
+          command: | 
+            GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone -b "update-nvrf-pdf" "$CIRCLE_REPOSITORY_URL"      
+            gh/install
             git config user.email "circleci@df52e93b2563.(none)"
             git config user.name "Pipeline Commit"
+      #configure git
+      # - run:
+      #     name: Configure git
+      #     command: |
+      #       # ssh-keyscan github.com >> ~/.ssh/known_hosts
+      #       git config user.email "circleci@df52e93b2563.(none)"
+      #       git config user.name "Pipeline Commit"
       - run:
           name: Fetch NVRF from eac.gov
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       #Install gh
       - gh/install
-      - run: 
+      - run:
           name: Git Cone and Config
-          command: | 
+          command: |
             GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone -b "update-nvrf-pdf" "$CIRCLE_REPOSITORY_URL"
             cd vote-gov-nvrf-app
             git config user.email "circleci@df52e93b2563.(none)"
@@ -43,6 +43,7 @@ jobs:
             echo $STORED_ARTIFACTS > $NVRF_FILE_NAME
       - run:
           name: Create Pull Request
+          shell: /bin/bash
           command: |
             cd vote-gov-nvrf-app
             echo $NVRF_PDF_WRITE | tee /tmp/key.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       #Install gh
       - gh/install
       - run:
-          name: Git Cone and Config
+          name: Git Clone and Config
           command: |
             GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone -b "update-nvrf-pdf" "$CIRCLE_REPOSITORY_URL"
             cd vote-gov-nvrf-app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - run:
           name: Configure git
           command: |
-            ssh-keyscan <github.com> >> ~/.ssh/known_hosts
+            # ssh-keyscan github.com >> ~/.ssh/known_hosts
             git config user.email "circleci@df52e93b2563.(none)"
             git config user.name "Pipeline Commit"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,7 @@ jobs:
           name: git stuff
           command: | 
             GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone -b "update-nvrf-pdf" "$CIRCLE_REPOSITORY_URL"
-            pwd 
-            ls -l      
+            cd vote-gov-nvrf-app
             # gh/install
             git config user.email "circleci@df52e93b2563.(none)"
             git config user.name "Pipeline Commit"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,8 @@ jobs:
       NEW_BRANCH_NAME: upload-nvrf-pdf
     steps:
       #checkout pdf branch and install gh
-      - run: git clone -b "update-nvrf-pdf" "$CIRCLE_REPOSITORY_URL"
+      # - run: git clone -b "update-nvrf-pdf" "$CIRCLE_REPOSITORY_URL"
+      - run: GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone -b "update-nvrf-pdf" "$CIRCLE_REPOSITORY_URL"      
       - gh/install
       #configure git
       - run:
@@ -71,10 +72,10 @@ workflows:
   update-nvrf-workflow:
     jobs:
       - update-nvrf
-    triggers:
-      - schedule:
-          cron: '0 0 * * 5'
-          filters:
-            branches:
-              only:
-                - stage
+    # triggers:
+    #   - schedule:
+    #       cron: '0 0 * * 5'
+    #       filters:
+    #         branches:
+    #           only:
+    #             - stage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
             cd vote-gov-nvrf-app
             echo $NVRF_PDF_WRITE | tee /tmp/key.txt
             gh auth login --with-token < /tmp/key.txt
-            gh pr create --title "Update NVRF PDF" --body "Upload the new NVRF PDF from eac.gov. This is an automated job from CircleCI"
+            gh pr create --title "Update NVRF PDF" --body "Upload the new NVRF PDF from eac.gov. This is an automated job from CircleCI" || true
   cypress-testing:
     docker:
       - image: cypress/included:cypress-13.3.0-node-20.6.1-chrome-116.0.5845.187-1-ff-117.0-edge-116.0.1938.76-1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,28 +10,20 @@ jobs:
       NVRF_FILE_NAME: Federal_Voter_Registration_ENG.pdf
       NEW_BRANCH_NAME: upload-nvrf-pdf
     steps:
-      #checkout pdf branch and install gh
-      # - run: git clone -b "update-nvrf-pdf" "$CIRCLE_REPOSITORY_URL"
+      #Install gh
       - gh/install
       - run: 
-          name: git stuff
+          name: Git Cone and Config
           command: | 
             GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone -b "update-nvrf-pdf" "$CIRCLE_REPOSITORY_URL"
             cd vote-gov-nvrf-app
             git config user.email "circleci@df52e93b2563.(none)"
             git config user.name "Pipeline Commit"
-      #configure git
-      # - run:
-      #     name: Configure git
-      #     command: |
-      #       # ssh-keyscan github.com >> ~/.ssh/known_hosts
-      #       git config user.email "circleci@df52e93b2563.(none)"
-      #       git config user.name "Pipeline Commit"
       - run:
           name: Fetch NVRF from eac.gov
           command: |
             curl -o Federal_Voter_Registration_ENG.pdf $URL
-      #save pdf as an artifact
+      #Save pdf as an artifact
       - store_artifacts:
           path: Federal_Voter_Registration_ENG.pdf
           destination: /pdf-files

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
       - run:
           name: Create Pull Request
           command: |
+            cd vote-gov-nvrf-app
             echo $NVRF_PDF_WRITE | tee /tmp/key.txt
             gh auth login --with-token < /tmp/key.txt
             gh pr create --title "Update NVRF PDF" --body "Upload the new NVRF PDF from eac.gov. This is an automated job from CircleCI"


### PR DESCRIPTION
VOTE-822

Changes to the NVRF PDF Upload job:
1. Change git clone to an git ssh clone command
2. Override default shell command in PR step
3. Override pipeline fail in PR command. Empty PR (resulting from no changes to the PDF) will not result in failed job