### PR TITLE
VOTE-1111 Fix reg button labels

### DIFF
--- a/src/components/RegType/OnlineNoNvrf.jsx
+++ b/src/components/RegType/OnlineNoNvrf.jsx
@@ -15,7 +15,7 @@ function OnlineNoNVRF(props) {
         const stateOnlineLink = () => (
             <p>
                 <a href={stateContent.registration_url} className="usa-button" target="_blank">
-                    <span>{stringContent.inPersonBtn.replace("@state_name", props.stateData.name)}</span>
+                    <span>{stringContent.stateOnlineName.replace("@state_name", props.stateData.name)}</span>
                     <Icon.Launch title={stringContent.extlink} style={{margin: "-3px -3px -3px 4px"}}/>
                 </a>
             </p>
@@ -33,7 +33,7 @@ function OnlineNoNVRF(props) {
         const checkRegLink = () => (
             <p>
                     <a href={stateContent.confirm_reg_url} className="usa-button" target="_blank">
-                        <span>{stringContent.inPersonBtn.replace("@state_name", stateContent.name)}</span>
+                        <span>{stringContent.checkReg.replace("@state_name", stateContent.name)}</span>
                         <Icon.Launch title={stringContent.extlink} style={{margin: "-3px -3px -3px 4px"}}/>
                     </a>
             </p>

--- a/src/components/RegType/OnlineNoStateMail.jsx
+++ b/src/components/RegType/OnlineNoStateMail.jsx
@@ -25,7 +25,7 @@ function OnlineNoStateMail(props) {
         const checkRegLink = () => (
             <p>
                 <a href={stateContent.confirm_reg_url} className="usa-button" target="_blank">
-                    <span>{stringContent.inPersonBtn.replace("@state_name", stateContent.name)}</span>
+                    <span>{stringContent.checkReg.replace("@state_name", stateContent.name)}</span>
                     <Icon.Launch title={stringContent.extlink} style={{margin: "-3px -3px -3px 4px"}}/>
                 </a>
             </p>

--- a/src/components/RegType/OnlineOnly.jsx
+++ b/src/components/RegType/OnlineOnly.jsx
@@ -15,7 +15,7 @@ function OnlineOnly(props) {
         const stateOnlineLink = () => (
             <p>
                 <a href={stateContent.registration_url} className="usa-button" target="_blank">
-                    <span>{stringContent.inPersonBtn.replace("@state_name", stateContent.name)}</span>
+                    <span>{stringContent.stateOnlineName.replace("@state_name", stateContent.name)}</span>
                     <Icon.Launch title={stringContent.extlink} style={{margin: "-3px -3px -3px 4px"}}/>
                 </a>
             </p>
@@ -24,7 +24,7 @@ function OnlineOnly(props) {
         const checkRegLink = () => (
             <p>
                 <a href={stateContent.confirm_reg_url} className="usa-button" target="_blank">
-                    <span>{stringContent.inPersonBtn.replace("@state_name", stateContent.name)}</span>
+                    <span>{stringContent.checkReg.replace("@state_name", stateContent.name)}</span>
                     <Icon.Launch title={stringContent.extlink} style={{margin: "-3px -3px -3px 4px"}}/>
                 </a>
             </p>


### PR DESCRIPTION
Fix a regression in the registration button labels. [VOTE-1111](https://cm-jira.usa.gov/browse/VOTE-1111)

Visit each of these state pages and confirm button labels are correct according to the content linked in the ticket.
1. Alaska (online)
2. Maine (all mail-in)
3. Guam (online, no nvrf, no state mail)
4. Wisconsin (online, no nvrf)
5. New Hampshire (mail, no nvrf)
6. North Dakota (no registration)
7. American Samoa (in person only)
8. Wyoming (state specific template)