### PR TITLE
Vote-868: Update to DOB field font size

### DIFF
--- a/src/components/GenerateFilledPDF.jsx
+++ b/src/components/GenerateFilledPDF.jsx
@@ -86,8 +86,14 @@ const GenerateFilledPDF = async function (btnType,formData,pagesKept) {
 
     //Date of Birth, Phone, Race
     dobMonth.setText(formData.date_of_birth_month);
+    // adjusting font size
+    dobMonth.setFontSize(12)
     dobDay.setText(formData.date_of_birth_day);
+    // adjusting font size
+    dobDay.setFontSize(12)
     dobYear.setText(formData.date_of_birth_year);
+    // adjusting font size
+    dobYear.setFontSize(5)
     phoneNumber.setText(formData.phone_number);
     race.setText(formData.race);
 


### PR DESCRIPTION
Ticket: [Vote-868](https://cm-jira.usa.gov/browse/VOTE-868)

Purpose:  Adjust text size for DOB field font sizes, currently the year for DOB is only 2 characters and not 4 so the year is getting cut off... now this will allow the user to have the full year showing.

Testing: Fill out form and check that the full year is showing for the DOB on the pdf form 