### PR TITLE
VOTE-1133 Replace hardcoded zip code help text with data from cms

### DIFF
--- a/public/data/en/strings.json
+++ b/public/data/en/strings.json
@@ -19,7 +19,6 @@
     "selectState": "Select your state or territory",
     "lastUpdated": "@state_name information last updated ",
     "privacyPolicy": "Privacy policy",
-    "zip": "For example: 12345",
     "extlink": "External link opens new window",
     "emailLabel": "Voter Contact",
     "emailHint": "For example: email@address.com",

--- a/src/components/FormSections/Addresses.jsx
+++ b/src/components/FormSections/Addresses.jsx
@@ -291,7 +291,7 @@ function Addresses(props){
                                 <Label className="text-bold" htmlFor="mail-zip-code">
                                     {mailZipcodeField.label} {(addressFieldsState.required === "1") && <span className={'required-text'}>*</span>}
                                 </Label>
-                                <span className="usa-hint" id="mail-zip-hint">For example: 12345</span>
+                                <span className="usa-hint" id="mail-zip-hint">{zipcodeField.help_text}</span>
                                 <TextInput
                                     data-test="mailZip"
                                     id="mail-zip-code"
@@ -440,7 +440,7 @@ function Addresses(props){
                                 <Label className="text-bold" htmlFor="prev-zip-code">
                                     {prevZipcodeField.label} {(addressFieldsState.required === "1") && <span className={'required-text'}>*</span>}
                                 </Label>
-                                <span className="usa-hint" id="prev-zip-hint">{stringContent.zip}</span>
+                                <span className="usa-hint" id="prev-zip-hint">{zipcodeField.help_text}</span>
                                 <TextInput
                                     data-test="prevZip"
                                     id="prev-zip-code"


### PR DESCRIPTION
Ticket: [VOTE-1133](https://cm-jira.usa.gov/browse/VOTE-1133)

Description: Replace hardcoded and duplicate help text for the mail zip code with the data from the CMS.

Test steps:
1. Start the form on the "Begin new registration" path for Alaska
2. On the address page, confirm that all zip code fields have the correct help text according to the ticket. (Current address, previous address, alt mail address)