### PR TITLE
VOTE-750: aria-label for State Selection component

### DIFF
--- a/public/data/en/strings.json
+++ b/public/data/en/strings.json
@@ -17,6 +17,7 @@
     "stateOnlineName": "Register on @state_name's website",
     "confirm": "Confirm and continue",
     "selectState": "Select your state or territory",
+    "selectStateAriaLabel": "State selection dropdown menu",
     "lastUpdated": "@state_name information last updated ",
     "privacyPolicy": "Privacy policy",
     "extlink": "External link opens new window",

--- a/src/components/StateSelection.jsx
+++ b/src/components/StateSelection.jsx
@@ -37,6 +37,7 @@ function StateSelection(props) {
                                 id="state-dropdown"
                                 data-test="dropDown"
                                 name="state-dropdown"
+                                aria-label={stringContent.selectStateAriaLabel}
                                 aria-describedby="state-dropdown_error"
                                 value={props.state}
                                 required={true}


### PR DESCRIPTION
Added an aria-label for the `StateSelection` component that appears on the first page of the NVRF app. The aria-label message is written in `strings.json`.