### PR TITLE
VOTE-1021: no-id describe-text is read by screen reader

### DIFF
--- a/public/data/en/fields.json
+++ b/public/data/en/fields.json
@@ -240,7 +240,7 @@
     "label": "I do not have a valid ID.",
     "help_text": false,
     "error_msg": false,
-    "instructions": "\u003Cp\u003E\u0022None\u0022 will appear on your completed form.\u003C\/p\u003E",
+    "instructions": "\u0022None\u0022 will appear on your completed form.",
     "section_description": "",
     "section_alert": "",
     "options": []

--- a/src/components/FormSections/Identification.jsx
+++ b/src/components/FormSections/Identification.jsx
@@ -200,10 +200,7 @@ function Identification(props){
                     </span>
                 </>}
                 
-            {props.idType === 'none' && 
-                <>
-                    <div aria-describedby="no-id-warning" dangerouslySetInnerHTML={{__html: `<p>${noIdFieldInstructions}</p>`}}/>
-                </>}
+            {props.idType === 'none' && <div dangerouslySetInnerHTML={{__html: `<p>${noIdFieldInstructions}</p>`}}/>}
         </div>
         </>
     );

--- a/src/components/FormSections/Identification.jsx
+++ b/src/components/FormSections/Identification.jsx
@@ -72,7 +72,14 @@ function Identification(props){
                         </React.Fragment>
                         </Select>
                         <span id="id-selection_error" role="alert" className='error-text' data-test="errorText">
-                            {stateIDField.error_msg}
+                            {props.idType == 'none' ?
+                                <>
+                                    {noIdFieldInstructions}
+                                </>
+                                :
+                                <>
+                                    {stateIDField.error_msg}
+                                </>}
                         </span>
                     </div>
                 </>
@@ -192,8 +199,11 @@ function Identification(props){
                         {ssnFullField.error_msg}
                     </span>
                 </>}
-            {props.idType === 'none' && <div aria-describedby="no-id-warning" dangerouslySetInnerHTML={{__html: `<p>${noIdFieldInstructions}</p>`}}/>}
-            <span id="no-id-warning" role="alert" className='error-text'>{noIdFieldInstructions}</span>
+                
+            {props.idType === 'none' && 
+                <>
+                    <div aria-describedby="no-id-warning" dangerouslySetInnerHTML={{__html: `<p>${noIdFieldInstructions}</p>`}}/>
+                </>}
         </div>
         </>
     );

--- a/src/components/FormSections/Identification.jsx
+++ b/src/components/FormSections/Identification.jsx
@@ -192,8 +192,8 @@ function Identification(props){
                         {ssnFullField.error_msg}
                     </span>
                 </>}
-
-            {props.idType === 'none' && <div dangerouslySetInnerHTML={{__html: noIdFieldInstructions}}/>}
+            {props.idType === 'none' && <div aria-describedby="no-id-warning" dangerouslySetInnerHTML={{__html: `<p>${noIdFieldInstructions}</p>`}}/>}
+            <span id="no-id-warning" role="alert" className='error-text'>{noIdFieldInstructions}</span>
         </div>
         </>
     );


### PR DESCRIPTION
Added no-id message to where aria-describedby points to so that the screen reader can read it when no-id option is selected.