### PR TITLE
VOTE-1022: Move political party help text above text field

### DIFF
--- a/public/data/en/fields.json
+++ b/public/data/en/fields.json
@@ -5,9 +5,9 @@
     "nvrf_id": "choice_of_party",
     "name": "Choice of party",
     "label": "Enter the full name of the political party you wish to join or leave blank.",
-    "help_text": false,
+    "help_text": "If you don\u0027t want to register with any political party, leave this field blank. You can still vote in general elections and open primary elections. But if your state holds a partisan primary election, you\u0027ll need to register with that party to vote in the partisan primary election.",
     "error_msg": "Choice of party must be filled out.",
-    "instructions": "\u003Cp\u003EIf you don\u0027t want to register with any political party, leave this field blank. You can still vote in general elections and open primary elections. But if your state holds a partisan primary election, you\u0027ll need to register with that party to vote in the partisan primary election.\u003C\/p\u003E",
+    "instructions": "",
     "section_description": "",
     "section_alert": "",
     "options": []

--- a/public/data/en/fields.json
+++ b/public/data/en/fields.json
@@ -5,9 +5,9 @@
     "nvrf_id": "choice_of_party",
     "name": "Choice of party",
     "label": "Enter the full name of the political party you wish to join or leave blank.",
-    "help_text": "If you don\u0027t want to register with any political party, leave this field blank. You can still vote in general elections and open primary elections. But if your state holds a partisan primary election, you\u0027ll need to register with that party to vote in the partisan primary election.",
+    "help_text": false,
     "error_msg": "Choice of party must be filled out.",
-    "instructions": "",
+    "instructions": "If you don\u0027t want to register with any political party, leave this field blank. You can still vote in general elections and open primary elections. But if your state holds a partisan primary election, you\u0027ll need to register with that party to vote in the partisan primary election.",
     "section_description": "",
     "section_alert": "",
     "options": []

--- a/src/components/FormSections/PoliticalParty.jsx
+++ b/src/components/FormSections/PoliticalParty.jsx
@@ -34,6 +34,7 @@ function PoliticalParty(props){
                 <Label className="text-bold" htmlFor="political-party">
                     {partyField.name}{(partyFieldState.required === "1") && <span className='required-text'>*</span>}
                 </Label>
+                <span className="usa-hint" id="political-party_hint">{partyField.help_text}</span>
                 <TextInput
                     data-test="politicalParty"
                     id="political-party"
@@ -54,7 +55,6 @@ function PoliticalParty(props){
                     {partyField.error_msg}
                 </span>
             </div>
-            <div dangerouslySetInnerHTML={{ __html: partyGeneralInstructions }} />
             </>
         )}
         </>

--- a/src/components/FormSections/PoliticalParty.jsx
+++ b/src/components/FormSections/PoliticalParty.jsx
@@ -12,7 +12,6 @@ function PoliticalParty(props){
 
     //Drupal field data
     const partyField = fields.find(item => item.uuid === "fd516f06-11bb-4c39-9080-735ed98100cc");
-    const partyGeneralInstructions = sanitizeDOM(partyField.instructions)
 
     //Field requirements by state data
     const partyFieldState = (nvrfStateFields.find(item => item.uuid === partyField.uuid));
@@ -21,7 +20,7 @@ function PoliticalParty(props){
         <>
         <h2>{headings.step_label_4}</h2>
 
-        {(partyStateInstructions || partyGeneralInstructions) && (
+        {(partyStateInstructions) && (
         <div className="usa-alert usa-alert--info" role="region" aria-live="polite">
             <div className="usa-alert__body">
                 <div className="usa-alert__text" dangerouslySetInnerHTML={{__html: partyStateInstructions}}/>

--- a/src/components/FormSections/PoliticalParty.jsx
+++ b/src/components/FormSections/PoliticalParty.jsx
@@ -12,6 +12,7 @@ function PoliticalParty(props){
 
     //Drupal field data
     const partyField = fields.find(item => item.uuid === "fd516f06-11bb-4c39-9080-735ed98100cc");
+    const partyGeneralInstructions = sanitizeDOM(partyField.instructions)
 
     //Field requirements by state data
     const partyFieldState = (nvrfStateFields.find(item => item.uuid === partyField.uuid));
@@ -20,7 +21,7 @@ function PoliticalParty(props){
         <>
         <h2>{headings.step_label_4}</h2>
 
-        {(partyStateInstructions) && (
+        {(partyStateInstructions || partyGeneralInstructions) && (
         <div className="usa-alert usa-alert--info" role="region" aria-live="polite">
             <div className="usa-alert__body">
                 <div className="usa-alert__text" dangerouslySetInnerHTML={{__html: partyStateInstructions}}/>
@@ -33,7 +34,7 @@ function PoliticalParty(props){
                 <Label className="text-bold" htmlFor="political-party">
                     {partyField.name}{(partyFieldState.required === "1") && <span className='required-text'>*</span>}
                 </Label>
-                <span className="usa-hint" id="political-party_hint">{partyField.help_text}</span>
+                <span className="usa-hint" id="political-party_hint">{partyGeneralInstructions}</span>
                 <TextInput
                     data-test="politicalParty"
                     id="political-party"


### PR DESCRIPTION
Moved the help text for the political party selection field from below the text input box to above.

**Before**:
![image](https://github.com/usagov/vote-gov-nvrf-app/assets/78001945/674fab10-821b-493b-8247-b66b7a528904)
*it seems like this screenshot was from an older version, and more content has been added to the help text since then.

**After**:
![image](https://github.com/usagov/vote-gov-nvrf-app/assets/78001945/76472176-af10-489a-a1f7-db93bcde5114)

The text type was also changed from `"instructions"` to `"help_text"` in the JSON, and a `<span>` tag was used instead of `dangerouslySetInnerHTML`. Other text fields in the app appear to have help text added via `<span>` tags, while instructions are added via `dangerouslySetInnerHTML`, so I made sure that this was consistent.

*minor note: some of the text content in the help text is somewhat redundant with the text in the blue info box above