### PR TITLE
VOTE-1979: Make completed form segments clickable

### DIFF
--- a/public/theme/assets/styles/nvrf.css
+++ b/public/theme/assets/styles/nvrf.css
@@ -52,7 +52,8 @@
 
 .nvrf-app-container .usa-step-indicator__segment--complete {
     cursor: pointer;
-    &:hover {
+    &:hover,
+    &:focus {
         text-decoration: underline;
     }
 }

--- a/public/theme/assets/styles/nvrf.css
+++ b/public/theme/assets/styles/nvrf.css
@@ -46,6 +46,10 @@
     }
 }
 
+.nvrf-app-container .usa-step-indicator__segment {
+    cursor: default;
+}
+
 .nvrf-app-container .usa-step-indicator__segment--complete {
     cursor: pointer;
     &:hover {

--- a/public/theme/assets/styles/nvrf.css
+++ b/public/theme/assets/styles/nvrf.css
@@ -48,6 +48,9 @@
 
 .nvrf-app-container .usa-step-indicator__segment--complete {
     cursor: pointer;
+    &:hover {
+        text-decoration: underline;
+    }
 }
 
 .nvrf-app-container .usa-alert__text {

--- a/public/theme/assets/styles/nvrf.css
+++ b/public/theme/assets/styles/nvrf.css
@@ -46,6 +46,10 @@
     }
 }
 
+.nvrf-app-container .usa-step-indicator__segment--complete {
+    cursor: pointer;
+}
+
 .nvrf-app-container .usa-alert__text {
     > *:first-child {
         margin-top: 0;

--- a/src/components/MultiStepForm.jsx
+++ b/src/components/MultiStepForm.jsx
@@ -253,7 +253,7 @@ function MultiStepForm(props) {
         <>
             {step != 6 && <BackButton stringContent={stringContent} type={'button'} onClick={handlePrev} text={backButtonText(step)}/>}
 
-            <ProgressBar step={step} content={navContent} handleGoBack={handleGoBackSteps} />
+            <ProgressBar step={step} content={navContent} handleGoBack={handleGoBackSteps} setStep={setStep} />
             <div className={'usa-prose margin-top-8 maxw-tablet margin-x-auto'}>
             {step < 5 &&
                 <>

--- a/src/components/MultiStepForm.jsx
+++ b/src/components/MultiStepForm.jsx
@@ -253,7 +253,7 @@ function MultiStepForm(props) {
         <>
             {step != 6 && <BackButton stringContent={stringContent} type={'button'} onClick={handlePrev} text={backButtonText(step)}/>}
 
-            <ProgressBar step={step} content={navContent}/>
+            <ProgressBar step={step} content={navContent} handleGoBack={handleGoBackSteps} />
             <div className={'usa-prose margin-top-8 maxw-tablet margin-x-auto'}>
             {step < 5 &&
                 <>

--- a/src/components/ProgressBar.jsx
+++ b/src/components/ProgressBar.jsx
@@ -23,20 +23,37 @@ function ProgressBar(props) {
     
     const handleGoBackSteps = props.handleGoBack;
 
+    const setStep = props.setStep;
+
     return (
         <>
             <div aria-live="polite" aria-atomic="true" className="usa-sr-only">{currentStepMessage}</div>
             <StepIndicator centered className="margin-top-4" headingLevel="h2">
                 <StepIndicatorStep label={props.content.step_label_1} status={stepProgress(1)} 
+                tabIndex={stepProgress(1) === "complete" ? 0 : -1}
+                onKeyDown={(e) => {if (e.key === "Enter" && stepProgress(1) === "complete") {setStep(1)}}}
                 onClick={stepProgress(1) === "complete" ? handleGoBackSteps(props.step - 1) : null}/>
+
                 <StepIndicatorStep label={props.content.step_label_2} status={stepProgress(2)} 
+                tabIndex={stepProgress(2) === "complete" ? 0 : -1}
+                onKeyDown={(e) => {if (e.key === "Enter" && stepProgress(2) === "complete") {setStep(2)}}}
                 onClick={stepProgress(2) === "complete" ? handleGoBackSteps(props.step - 2) : null}/>
+
                 <StepIndicatorStep label={props.content.step_label_3} status={stepProgress(3)} 
+                tabIndex={stepProgress(3) === "complete" ? 0 : -1}
+                onKeyDown={(e) => {if (e.key === "Enter" && stepProgress(3) === "complete") {setStep(3)}}}
                 onClick={stepProgress(3) === "complete" ? handleGoBackSteps(props.step - 3) : null}/>
+
                 <StepIndicatorStep label={props.content.step_label_4} status={stepProgress(4)} 
+                tabIndex={stepProgress(4) === "complete" ? 0 : -1}
+                onKeyDown={(e) => {if (e.key === "Enter" && stepProgress(4) === "complete") {setStep(4)}}}
                 onClick={stepProgress(4) === "complete" ? handleGoBackSteps(props.step - 4) : null}/>
+
                 <StepIndicatorStep label={props.content.step_label_5} status={stepProgress(5)} 
+                tabIndex={stepProgress(5) === "complete" ? 0 : -1}
+                onKeyDown={(e) => {if (e.key === "Enter" && stepProgress(5) === "complete") {setStep(5)}}}
                 onClick={stepProgress(5) === "complete" ? handleGoBackSteps(props.step - 5) : null}/>
+                
                 <StepIndicatorStep label={props.content.step_label_6} status={stepProgress(6)}/>
             </StepIndicator>
         </>

--- a/src/components/ProgressBar.jsx
+++ b/src/components/ProgressBar.jsx
@@ -20,16 +20,23 @@ function ProgressBar(props) {
         }
         else null
       }
+    
+    const handleGoBackSteps = props.handleGoBack;
 
     return (
         <>
             <div aria-live="polite" aria-atomic="true" className="usa-sr-only">{currentStepMessage}</div>
             <StepIndicator centered className="margin-top-4" headingLevel="h2">
-                <StepIndicatorStep label={props.content.step_label_1} status={stepProgress(1)}/>
-                <StepIndicatorStep label={props.content.step_label_2} status={stepProgress(2)}/>
-                <StepIndicatorStep label={props.content.step_label_3} status={stepProgress(3)}/>
-                <StepIndicatorStep label={props.content.step_label_4} status={stepProgress(4)}/>
-                <StepIndicatorStep label={props.content.step_label_5} status={stepProgress(5)}/>
+                <StepIndicatorStep label={props.content.step_label_1} status={stepProgress(1)} 
+                onClick={stepProgress(1) === "complete" ? handleGoBackSteps(props.step - 1) : null}/>
+                <StepIndicatorStep label={props.content.step_label_2} status={stepProgress(2)} 
+                onClick={stepProgress(2) === "complete" ? handleGoBackSteps(props.step - 2) : null}/>
+                <StepIndicatorStep label={props.content.step_label_3} status={stepProgress(3)} 
+                onClick={stepProgress(3) === "complete" ? handleGoBackSteps(props.step - 3) : null}/>
+                <StepIndicatorStep label={props.content.step_label_4} status={stepProgress(4)} 
+                onClick={stepProgress(4) === "complete" ? handleGoBackSteps(props.step - 4) : null}/>
+                <StepIndicatorStep label={props.content.step_label_5} status={stepProgress(5)} 
+                onClick={stepProgress(5) === "complete" ? handleGoBackSteps(props.step - 5) : null}/>
                 <StepIndicatorStep label={props.content.step_label_6} status={stepProgress(6)}/>
             </StepIndicator>
         </>


### PR DESCRIPTION
Added functionality to make completed form segments (navy blue color) clickable, where clicking on a completed segment will allow the user to jump back to that specific section of the form. When hovering over the segment for a completed section, the mouse pointer indicates that the section is clickable, but does not do so for the current section (blue) and future sections (gray). Clicking on the current section or a future section does not do anything (preventing the user from skipping ahead).

Demo:
![Untitled video - Made with Clipchamp](https://github.com/usagov/vote-gov-nvrf-app/assets/78001945/c758dea2-764b-474c-b93c-f237e60da392)
