### PR TITLE
VOTE 2030: Adding instructions for checkboxes on address page

### DIFF
--- a/public/data/en/fields.json
+++ b/public/data/en/fields.json
@@ -421,7 +421,7 @@
     "label": "I have moved since I last registered in this state.",
     "help_text": false,
     "error_msg": false,
-    "instructions": "",
+    "instructions": "Please only select one of the following checkboxes if it is applicable to you.",
     "section_description": "",
     "section_alert": "",
     "options": []
@@ -537,7 +537,7 @@
     "label": "I do not have a street address.",
     "help_text": false,
     "error_msg": false,
-    "instructions": "",
+    "instructions": "Please only select the checkbox below if it is applicable to you.",
     "section_description": "",
     "section_alert": "",
     "options": []

--- a/public/data/en/fields.json
+++ b/public/data/en/fields.json
@@ -421,7 +421,7 @@
     "label": "I have moved since I last registered in this state.",
     "help_text": false,
     "error_msg": false,
-    "instructions": "Please only select one of the following checkboxes if it is applicable to you.",
+    "instructions": "",
     "section_description": "",
     "section_alert": "",
     "options": []
@@ -537,7 +537,7 @@
     "label": "I do not have a street address.",
     "help_text": false,
     "error_msg": false,
-    "instructions": "Please only select the checkbox below if it is applicable to you.",
+    "instructions": "",
     "section_description": "",
     "section_alert": "",
     "options": []

--- a/src/components/FormSections/Addresses.jsx
+++ b/src/components/FormSections/Addresses.jsx
@@ -2,6 +2,7 @@ import { Label, TextInput, Checkbox, Grid } from '@trussworks/react-uswds';
 import StateSelector from '../StateSelector';
 import React, { useState } from "react";
 import { restrictType, checkForErrors, toggleError } from '../HelperFunctions/ValidateField';
+import { sanitizeDOM } from '../HelperFunctions/JsonHelper';
 
 
 function Addresses(props){
@@ -39,14 +40,24 @@ function Addresses(props){
     //Field requirements by state data
     const addressFieldsState = (nvrfStateFields.find(item => item.uuid === streetAddressField.uuid));
 
+    // Instructions for optional checkboxes (prev address, no address)
+    const addressCheckBoxInstructions = sanitizeDOM(noAddressField.instructions);
+    const addressCheckBoxesInstructions = sanitizeDOM(prevAddressField.instructions);
+
     return (
         <>
         <h2>{headings.step_label_2}</h2>
 
         {addressFieldsState && (
             <>
+            {!changeRegistrationVisible && (
+                <span className='usa-hint' id='addresses-checkbox_hint'>{addressCheckBoxInstructions}</span>
+            )}
             { changeRegistrationVisible && (
+                <>
+                <span className='usa-hint' id='addresses-checkbox_hint'>{addressCheckBoxesInstructions}</span>
                 <Checkbox id="prev-address" name="prev-address" data-test="checkBox" checked={props.hasPreviousAddress} onChange={props.onChangePreviousAddressCheckbox} label={prevAddressField.label} />
+                </>
             )}
                 <Checkbox id="no-address" aria-describedby="no-address_alert" className="margin-bottom-4" name="no-addr" data-test="checkBox" checked={props.hasNoAddress} onChange={props.hasNoAddressCheckbox} label={noAddressField.label} />
                 {/******** Current Address Block *********/}

--- a/src/components/FormSections/Addresses.jsx
+++ b/src/components/FormSections/Addresses.jsx
@@ -51,11 +51,11 @@ function Addresses(props){
         {addressFieldsState && (
             <>
             {!changeRegistrationVisible && (
-                <span className='usa-hint' id='addresses-checkbox_hint'>{addressCheckBoxInstructions}</span>
+                <span className='usa-hint' id='addresses-checkbox-hint'>{addressCheckBoxInstructions}</span>
             )}
             { changeRegistrationVisible && (
                 <>
-                <span className='usa-hint' id='addresses-checkbox_hint'>{addressCheckBoxesInstructions}</span>
+                <span className='usa-hint' id='addresses-checkbox-hint'>{addressCheckBoxesInstructions}</span>
                 <Checkbox id="prev-address" name="prev-address" data-test="checkBox" checked={props.hasPreviousAddress} onChange={props.onChangePreviousAddressCheckbox} label={prevAddressField.label} />
                 </>
             )}


### PR DESCRIPTION
Added instructions for the optional checkbox(es) at the top of the "Address and location" page. If the user is updating a current registration, two checkboxes will appear on the page, like below:
![image](https://github.com/usagov/vote-gov-nvrf-app/assets/78001945/af0afa24-c748-4fc9-8426-293772fb88aa)
The added instructions above the checkboxes reflect that there are two checkboxes.

If the user is creating a new registration, only one checkbox appears on the page, like below:
![image](https://github.com/usagov/vote-gov-nvrf-app/assets/78001945/ee0ac68a-0474-4f3a-94ae-21be307129af)
The instructions also reflect this.