### PR TITLE
VOTE-668: DOB disallow future date

### DIFF
--- a/src/components/FormSections/PersonalInfo.jsx
+++ b/src/components/FormSections/PersonalInfo.jsx
@@ -61,8 +61,8 @@ function PersonalInfo(props){
             day >= 1,
             yearStart <= 20,
             yearStart >= 19,
-            age <= 110,
-            age >= 17
+            age <= 120,
+            age >= 16
           ];
 
           if (dobValues.includes(false)) {

--- a/src/components/FormSections/PersonalInfo.jsx
+++ b/src/components/FormSections/PersonalInfo.jsx
@@ -297,7 +297,7 @@ function PersonalInfo(props){
                                     required={true}
                                     aria-invalid={false}
                                     type="text"
-                                    pattern="19\d{2}|20\d{2}"
+                                    pattern="19\d{2}|200\d{1}"
                                     inputMode="numeric"
                                     minLength={4}
                                     maxLength={4}

--- a/src/components/FormSections/PersonalInfo.jsx
+++ b/src/components/FormSections/PersonalInfo.jsx
@@ -45,7 +45,7 @@ function PersonalInfo(props){
 
         let currentDate = new Date();
         let currentMonth = currentDate.getMonth();
-        let currentDay = currentDate.getDay();
+        let currentDay = currentDate.getDate();
         let currentYear = currentDate.getFullYear();
         let age = currentYear - year - (currentMonth <= month && currentDay < day);
 

--- a/src/components/FormSections/PersonalInfo.jsx
+++ b/src/components/FormSections/PersonalInfo.jsx
@@ -37,32 +37,36 @@ function PersonalInfo(props){
     const telephoneFieldState = (nvrfStateFields.find(item => item.uuid === phoneNumberField.uuid));
     const raceFieldState = (nvrfStateFields.find(item => item.uuid === raceField.uuid));
 
-    const checkDateValues = (type) => {
+    const checkDateValues = (e, type) => {
         let month = props.fieldData.date_of_birth_month;
         let day = props.fieldData.date_of_birth_day;
-        /* removing age validation temporarily */
-        // let year = props.fieldData.date_of_birth_year;
-        // let yearStart = year.slice(0, 2);
-        // let birthdate = year + '-' + month + '-' + day;
-        // let age = Math.floor((new Date() - new Date(birthdate).getTime()) / 3.15576e+10)
+        let year = props.fieldData.date_of_birth_year;
+        let yearStart = year.slice(0, 2);
+
+        let currentDate = new Date();
+        let currentMonth = currentDate.getMonth();
+        let currentDay = currentDate.getDay();
+        let currentYear = currentDate.getFullYear();
+        let age = currentYear - year - (currentMonth <= month && currentDay < day);
 
         if (type === "all") {
           let dobValues = [
             month.length === 2,
             day.length === 2,
-            // year.length === 4,
+            year.length === 4,
 
             month <= 12,
             month >= 1,
             day <= 31,
             day >= 1,
-            // yearStart <= 20,
-            // yearStart >= 19,
-            // age <= 110,
-            // age >= 17
+            yearStart <= 20,
+            yearStart >= 19,
+            age <= 110,
+            age >= 17
           ];
 
           if (dobValues.includes(false)) {
+            e.target.setCustomValidity(' ');
             return true
           } else {
             return false
@@ -80,13 +84,12 @@ function PersonalInfo(props){
           } else {
             return false
           }
-        /* removing age validation temporarily */
-        // } else if (type === "year") {
-        //   if (age > 110 || age < 17) {
-        //     return true
-        //   } else {
-        //     return false
-        //   }
+        } else if (type === "year") {
+          if (age > 110 || age < 17) {
+            return true
+          } else {
+            return false
+          }
         }
       };
 
@@ -223,7 +226,7 @@ function PersonalInfo(props){
                             autoComplete="off"
                             required={parseInt(dobFieldState.required)}
                             data-testid="dateInputGroup"
-                            onBlur={e => { if (!e.currentTarget.contains(e.relatedTarget)) toggleError(e, checkDateValues('all')) }}
+                            onBlur={e => { if (!e.currentTarget.contains(e.relatedTarget)) toggleError(e, checkDateValues(e, 'all')) }}
                             >
                             <div data-testid="formGroup" className="usa-form-group usa-form-group--month">
                                 <label data-testid="label" className="usa-label" htmlFor="date-of-birth_month">
@@ -248,7 +251,7 @@ function PersonalInfo(props){
                                     onInput={props.saveFieldData('date_of_birth_month')}
                                     onKeyUp={(e) => jumpTo(e, 'date-of-birth_day')}
                                     onKeyDown={(e) => {restrictType(e, 'number'), e.target.setCustomValidity('')}}
-                                    onBlur={(e) => {props.dateFormat(e, 'date_of_birth_month'), toggleError(e, checkDateValues('month'))}}
+                                    onBlur={(e) => {props.dateFormat(e, 'date_of_birth_month'), toggleError(e, checkDateValues(e, 'month'))}}
                                     onInvalid={(e) => e.target.setCustomValidity(' ')}
                                     />
                             </div>
@@ -275,7 +278,7 @@ function PersonalInfo(props){
                                     onInput={props.saveFieldData('date_of_birth_day')}
                                     onKeyUp={(e) => jumpTo(e, 'date-of-birth_year')}
                                     onKeyDown={(e) => {restrictType(e, 'number'), e.target.setCustomValidity('')}}
-                                    onBlur={(e) => {props.dateFormat(e, 'date_of_birth_day'), toggleError(e, checkDateValues('day'))}}
+                                    onBlur={(e) => {props.dateFormat(e, 'date_of_birth_day'), toggleError(e, checkDateValues(e, 'day'))}}
                                     onInvalid={(e) => e.target.setCustomValidity(' ')}
                                     />
                             </div>
@@ -294,7 +297,7 @@ function PersonalInfo(props){
                                     required={true}
                                     aria-invalid={false}
                                     type="text"
-                                    pattern="19\d{2}|200\d{1}"
+                                    pattern="19\d{2}|20\d{2}"
                                     inputMode="numeric"
                                     minLength={4}
                                     maxLength={4}


### PR DESCRIPTION
[VOTE-668](https://cm-jira.usa.gov/browse/VOTE-668)

Uncommented age verification to verify the user is between 17 and 110.

p.s.
I'm not sure if enabling age verification was in the scope of this ticket, but entering future date was already not allowed as the regex is '200\{1}'

![image](https://github.com/usagov/vote-gov-nvrf-app/assets/172420491/612bf576-95ce-445d-80c0-a1c8700b71d2)

## Testing:

1. Go to Personal Information section.
2. In the DOB fields, verify you can't enter dates that make you younger than 16 and older than 120.