### PR TITLE
VOTE-2284: Revert party instructions content

### DIFF
--- a/public/data/en/fields.json
+++ b/public/data/en/fields.json
@@ -7,7 +7,7 @@
     "label": "Enter the full name of the political party you wish to join or leave blank.",
     "help_text": false,
     "error_msg": "Choice of party must be filled out.",
-    "instructions": "If you don\u0027t want to register with any political party, leave this field blank. You can still vote in general elections and open primary elections. But if your state holds a partisan primary election, you\u0027ll need to register with that party to vote in the partisan primary election.",
+    "instructions": "\u003Cp\u003EIf you don\u0027t want to register with any political party, leave this field blank. You can still vote in general elections and open primary elections. But if your state holds a partisan primary election, you\u0027ll need to register with that party to vote in the partisan primary election.\u003C\/p\u003E",
     "section_description": "",
     "section_alert": "",
     "options": []

--- a/src/components/FormSections/PoliticalParty.jsx
+++ b/src/components/FormSections/PoliticalParty.jsx
@@ -34,7 +34,7 @@ function PoliticalParty(props){
                 <Label className="text-bold" htmlFor="political-party">
                     {partyField.name}{(partyFieldState.required === "1") && <span className='required-text'>*</span>}
                 </Label>
-                <span className="usa-hint" id="political-party_hint">{partyGeneralInstructions}</span>
+                <div className="usa-hint" id="political-party_hint" dangerouslySetInnerHTML={{__html: partyGeneralInstructions}}/>
                 <TextInput
                     data-test="politicalParty"
                     id="political-party"


### PR DESCRIPTION
Jira ticket: https://cm-jira.usa.gov/browse/VOTE-2284
Reverted the political party selection instructions in fields.json to its original state (text content surrounded by `<p>` tags). In order to prevent the `<p>` tags from being visible to the user, the political party instructions are added using `dangerouslySetInnerHTML` (following how other instructions content from fields.json is added to the page). The text appears as follows:
![image](https://github.com/usagov/vote-gov-nvrf-app/assets/78001945/0bc44a2d-d1c5-409f-a6ea-77115ea7f27a)
