### PR TITLE
VOTE-2226: Add role to state/territory selector

### DIFF
--- a/src/components/StateSelection.jsx
+++ b/src/components/StateSelection.jsx
@@ -37,11 +37,11 @@ function StateSelection(props) {
                                 id="state-dropdown"
                                 data-test="dropDown"
                                 name="state-dropdown"
+                                role="select"
                                 aria-label={stringContent.selectStateAriaLabel}
                                 aria-describedby="state-dropdown_error"
                                 value={props.state}
                                 required={true}
-                                aria-invalid={false}
                                 onChange={e => {
                                     props.getSelectedState(e.target.value)
                                 }}


### PR DESCRIPTION
Added the `select` role to the state/territory selector element, and removed the `aria-invalid` attribute, which is not allowed on elements where role="select".