### PR TITLE
VOTE-776: Hide the step indicator progress bar on small screens

### DIFF
--- a/public/theme/assets/styles/nvrf.css
+++ b/public/theme/assets/styles/nvrf.css
@@ -39,7 +39,7 @@
 }
 
 .nvrf-app-container .usa-step-indicator__header {
-    @media (min-width: 640px) {
+    @media (min-width: 641px) {
         position: absolute;
         text-indent: -9000px;
         overflow: hidden;

--- a/public/theme/assets/styles/nvrf.css
+++ b/public/theme/assets/styles/nvrf.css
@@ -59,7 +59,7 @@
 }
 
 .nvrf-app-container .usa-step-indicator__segments {
-    @media (max-width: 639px) {
+    @media (max-width: 638px) {
         display: none;
     }
 }

--- a/public/theme/assets/styles/nvrf.css
+++ b/public/theme/assets/styles/nvrf.css
@@ -58,6 +58,12 @@
     }
 }
 
+.nvrf-app-container .usa-step-indicator__segments {
+    @media (max-width: 639px) {
+        display: none;
+    }
+}
+
 .nvrf-app-container .usa-alert__text {
     > *:first-child {
         margin-top: 0;

--- a/public/theme/assets/styles/nvrf.css
+++ b/public/theme/assets/styles/nvrf.css
@@ -59,7 +59,7 @@
 }
 
 .nvrf-app-container .usa-step-indicator__segments {
-    @media (max-width: 638px) {
+    @media (max-width: 640px) {
         display: none;
     }
 }


### PR DESCRIPTION
Jira ticket: https://cm-jira.usa.gov/browse/VOTE-776

Currently, when the screen width is <= 640px, the text on the progress bar will be hidden and a new "_ of 6: ..." label will appear. This fix hides the progress bar to avoid redundancy and prevent the user from accidentally clicking/tapping one of the previous segments, which would navigate them back to that segment.

Before:
![image](https://github.com/user-attachments/assets/44811c12-c639-4077-bea6-d8c8e2b8d34f)

After:
![image](https://github.com/user-attachments/assets/09fdc736-fb51-438b-8f16-aa0284311ea5)

To test this, open the NVRF app and navigate to the online form. Using the "responsive" dimensions on chrome dev tools, resize the width of the screen and verify that, at <=640px, the progress bar disappears and the new "_ of 6: ..." label appears.