### PR TITLE
VOTE-2287: Field Container for current title

### DIFF
--- a/src/Components/FieldComponents/SelectField.jsx
+++ b/src/Components/FieldComponents/SelectField.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Select } from '@trussworks/react-uswds';
 
-function SelectField({ inputData, saveFieldData, fieldData }){
+function SelectField({ inputData, saveFieldData, fieldData, stringContent }){
     return (
         <Select 
         data-test={inputData.dataTest}
@@ -17,7 +17,7 @@ function SelectField({ inputData, saveFieldData, fieldData }){
         onInput={(e) => e.target.setCustomValidity('')}
         >
         <React.Fragment key=".0">                        
-            <option value={''}>{inputData.stringContent}</option>
+            <option value={''}>{stringContent.select}</option>
             {inputData.options.map((item, index) => (
                 <option key={index} value={item.value}>{item.key}</option>
             ))}

--- a/src/Components/FieldContainer.jsx
+++ b/src/Components/FieldContainer.jsx
@@ -3,7 +3,7 @@ import { Label } from '@trussworks/react-uswds';
 import TextInputField from 'Components/FieldComponents/TextInputField';
 import SelectField from 'Components/FieldComponents/SelectField';
 
-function FieldContainer({ fieldType, inputData, saveFieldData, fieldData }) {
+function FieldContainer({ fieldType, inputData, saveFieldData, fieldData, stringContent }) {
   function renderField(fieldType) {
     switch (fieldType) {
       case 'text':
@@ -15,7 +15,8 @@ function FieldContainer({ fieldType, inputData, saveFieldData, fieldData }) {
         return <SelectField
           inputData={inputData}
           saveFieldData={saveFieldData}
-          fieldData={fieldData} />;
+          fieldData={fieldData} 
+          stringContent={stringContent} />;
     }
   };
 

--- a/src/Components/Fields/CurrentTitle.jsx
+++ b/src/Components/Fields/CurrentTitle.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import FieldContainer from 'Components/FieldContainer';
+import {getField} from "Utils/fieldParser";
+
+function CurrentTitle(props){
+    const uuid = "86a544cd-cfe9-456a-b634-176a37a38d6d";
+    const field = getField(props.fieldContent, uuid);
+    const stateField = getField(props.stateData.nvrf_fields, field.uuid);
+
+    return (
+        <FieldContainer
+            fieldType={'select'} inputData={{
+            id: 'title',
+            dataTest: 'title',
+            required: false,
+            label: field.label,
+            options: field.options,
+            error_msg: field.error_msg,
+            help_text: field.help_text,
+        }} saveFieldData={props.saveFieldData} fieldData={props.fieldData}/>
+    )
+}
+
+export default CurrentTitle;
+

--- a/src/Components/Fields/CurrentTitle.jsx
+++ b/src/Components/Fields/CurrentTitle.jsx
@@ -17,7 +17,7 @@ function CurrentTitle(props){
             options: field.options,
             error_msg: field.error_msg,
             help_text: field.help_text,
-        }} saveFieldData={props.saveFieldData} fieldData={props.fieldData}/>
+        }} saveFieldData={props.saveFieldData} fieldData={props.fieldData} stringContent={props.stringContent}/>
     )
 }
 

--- a/src/Views/FormPages/PersonalInfo.jsx
+++ b/src/Views/FormPages/PersonalInfo.jsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import { restrictType, checkForErrors, jumpTo, toggleError } from 'Utils/ValidateField';
 import {sanitizeDOM} from "Utils/JsonHelper";
 import CurrentFirstName from "Components/Fields/CurrentFirstName";
+import CurrentTitle from 'Components/Fields/CurrentTitle';
 
 function PersonalInfo(props){
     const headings = props.headings;
@@ -117,26 +118,7 @@ function PersonalInfo(props){
             <>
                 <Grid row gap>
                     <Grid tablet={{ col: 2 }}>
-                    <Label className="text-bold" htmlFor="title">
-                        {titleField.label}
-                    </Label>
-                    <Select
-                        className="radius-md" id="title" name="title"
-                        aria-describedby=""
-                        data-test="select"
-                        value={props.fieldData.title}
-                        onChange={props.saveFieldData('title')}
-                        autoComplete="off"
-                        onInvalid={(e) => e.target.setCustomValidity(' ')}
-                        onInput={(e) => e.target.setCustomValidity('')}>
-                        <React.Fragment key=".0"
-                    >
-                    <option value={''}>{stringContent.select}</option>
-                        {titleField.options.map((item, index) => (
-                            <option key={index} value={item.value}>{item.key}</option>
-                        ))}
-                    </React.Fragment>
-                    </Select>
+                    <CurrentTitle {...props} />
                     </Grid>
 
                 <Grid tablet={{ col: 5 }}>


### PR DESCRIPTION
Added a field container for the current title Select element. The element functions as expected, and the value chosen by the user appears in the filled PDF.
Note: the original default value ("-Select-") is replaced by a blank option as the default value. I think that "-Select-" would need to be added as an option in `fields.json`.
![image](https://github.com/user-attachments/assets/95c93b55-6d89-46f8-98c3-a74b80d5273f)

