### PR TITLE
VOTE-2289: Field Container for middle name

### DIFF
--- a/src/Components/Fields/CurrentMiddleName.jsx
+++ b/src/Components/Fields/CurrentMiddleName.jsx
@@ -10,7 +10,7 @@ function CurrentMiddleName(props){
     return (
         <FieldContainer
             fieldType={'text'} inputData={{
-            id: field.nvrf_id,
+            id: 'middle_name',
             dataTest: 'middleName',
             required: false,
             label: field.label,

--- a/src/Components/Fields/CurrentMiddleName.jsx
+++ b/src/Components/Fields/CurrentMiddleName.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+import FieldContainer from 'Components/FieldContainer';
+import {getField} from "Utils/fieldParser";
+
+function CurrentMiddleName(props){
+    const uuid = "38020ec6-1b53-4227-99e5-feea5f60af07";
+    const field = getField(props.fieldContent, uuid);
+    const stateField = getField(props.stateData.nvrf_fields, field.uuid);
+
+    return (
+        <FieldContainer
+            fieldType={'text'} inputData={{
+            id: field.nvrf_id,
+            dataTest: 'middleName',
+            required: false,
+            label: field.label,
+            error_msg: field.error_msg,
+            help_text: field.help_text,
+        }} saveFieldData={props.saveFieldData} fieldData={props.fieldData}/>
+    )
+}
+
+export default CurrentMiddleName;

--- a/src/Views/FormPages/PersonalInfo.jsx
+++ b/src/Views/FormPages/PersonalInfo.jsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import { restrictType, checkForErrors, jumpTo, toggleError } from 'Utils/ValidateField';
 import {sanitizeDOM} from "Utils/JsonHelper";
 import CurrentFirstName from "Components/Fields/CurrentFirstName";
+import CurrentMiddleName from 'Components/Fields/CurrentMiddleName';
 
 function PersonalInfo(props){
     const headings = props.headings;
@@ -144,20 +145,7 @@ function PersonalInfo(props){
                 </Grid>
 
                     <Grid tablet={{ col: 5 }}>
-                        <Label className="text-bold" htmlFor="middle-name">
-                            {middleNameField.label}
-                        </Label>
-                        <TextInput
-                            data-test="middleName"
-                            id="middle-name"
-                            className="radius-md"
-                            name="middle-name"
-                            aria-describedby=""
-                            value={props.fieldData.middle_name}
-                            onChange={props.saveFieldData('middle_name')}
-                            type="text" autoComplete="off"
-                            onInvalid={(e) => e.target.setCustomValidity(' ')}
-                            onInput={(e) => e.target.setCustomValidity('')}/>
+                    <CurrentMiddleName {...props} />
                     </Grid>
                 </Grid>
 


### PR DESCRIPTION
Added Field Container for the current middle name field. The field works as intended and the text entered appears in the filled PDF.

In fields.json, the current middle name field has help text ("If you do not have a middle name, leave this field blank.") that is not currently being used, but does appear now that a Field Container is being used. If we don't want this help text to appear, I think we could either delete it via CMS or I could set help_text to false in the Field Container (but leave the unused text in the JSON file).

If we want to keep the text, it appears that the alignment of the text fields becomes somewhat misaligned with the new help text. See below:
![image](https://github.com/user-attachments/assets/8e3b8bc3-b766-41ee-9bb0-8e28024f11ff)

I can adjust the CSS to re-align the text boxes if we do want to keep the text. See below:
![image](https://github.com/user-attachments/assets/33b4dca0-454b-45cf-be71-c26bd6b22226)
(this does create some extra empty space, but I'm not sure if there's a better way to align the boxes)
If we do want to include this CSS adjustment, I can add it to this PR.