### PR TITLE
VOTE-2489: Flex align all grid rows

### DIFF
--- a/src/Views/FormPages/Addresses.jsx
+++ b/src/Views/FormPages/Addresses.jsx
@@ -75,13 +75,13 @@ function Addresses(props){
                             <div dangerouslySetInnerHTML={{__html: homeAddressSectionField.instructions}}/>
                         )}
 
-                    <Grid row gap>
+                    <Grid row gap className={'flex-align-end'}>
                         <Grid tablet={{col: 12}}>
                             <CurrentStreetAddress {...props} />
                         </Grid>
                     </Grid>
 
-                    <Grid row gap>
+                    <Grid row gap className={'flex-align-end'}>
                         <Grid tablet={{ col: 5}}>
                             <CurrentApartmentNumber {...props} />
                         </Grid>
@@ -185,7 +185,7 @@ function Addresses(props){
                             <div dangerouslySetInnerHTML={{__html: mailAddressSectionField.section_description}}/>
                         )}
 
-                        <Grid row gap>
+                        <Grid row gap className={'flex-align-end'}>
                             <Grid tablet={{col: 12 }}>
                             <div className="input-parent">
                             <Label className="text-bold" htmlFor="mail-street">
@@ -317,7 +317,7 @@ function Addresses(props){
                             <div dangerouslySetInnerHTML={{__html: prevAddressSectionField.instructions}}/>
                         )}
 
-                        <Grid row gap>
+                        <Grid row gap className={'flex-align-end'}>
                             <Grid tablet={{ col: 12 }}>
                             <div className="input-parent">
                                 <Label className="text-bold" htmlFor="prev-street">

--- a/src/Views/FormPages/PersonalInfo.jsx
+++ b/src/Views/FormPages/PersonalInfo.jsx
@@ -115,7 +115,7 @@ function PersonalInfo(props){
 
         {nameFieldState && (
             <>
-                <Grid row gap>
+                <Grid row gap className={'flex-align-end'}>
                     <Grid tablet={{ col: 2 }}>
                     <Label className="text-bold" htmlFor="title">
                         {titleField.label}
@@ -161,7 +161,7 @@ function PersonalInfo(props){
                     </Grid>
                 </Grid>
 
-                <Grid row gap>
+                <Grid row gap className={'flex-align-end'}>
                     <Grid tablet={{ col: 6 }}>
                     <div className="input-parent">
                         <Label className="text-bold" htmlFor="last-name">
@@ -386,7 +386,7 @@ function PersonalInfo(props){
             </Grid>
 
             {raceFieldState && (
-                <Grid row gap>
+                <Grid row gap className={'flex-align-end'}>
                     <Grid tablet={{ col: 4 }}>
                         <div className="input-parent">
                             <Label className="text-bold" htmlFor="race-ethnicity">
@@ -422,7 +422,7 @@ function PersonalInfo(props){
         {(props.previousName && changeRegistrationVisible) && (
         <>
         <h3 className='margin-top-8'>{prevNameSectionField.label}</h3>
-        <Grid row gap>
+        <Grid row gap className={'flex-align-end'}>
             <Grid tablet={{ col: 2 }}>
             <Label className="text-bold" htmlFor="title-prev">
                 {prevTitleField.label}
@@ -490,7 +490,7 @@ function PersonalInfo(props){
             </Grid>
         </Grid>
 
-        <Grid row gap>
+        <Grid row gap className={'flex-align-end'}>
             <Grid tablet={{ col: 6 }}>
             <div className="input-parent">
                 <Label className="text-bold" htmlFor="last-name-prev">


### PR DESCRIPTION
[VOTE-2489](https://cm-jira.usa.gov/browse/VOTE-2489)

Originally DOB was the only field using the "hint" span. Now adding a hint to just one field on other rows causes the fields to not align together. This PR adds flex-align-end to all form rows the same way we did with the rows that have the date fieldsets. The fields should not shift now when one or more hints are added.

Before:
<img width="751" alt="Screenshot 2024-07-23 at 7 30 22 PM" src="https://github.com/user-attachments/assets/a599ade7-5152-423c-bfc4-bed993dfbd57">

Now:
<img width="780" alt="Screenshot 2024-07-23 at 7 37 07 PM" src="https://github.com/user-attachments/assets/be2e4c4b-06f8-47ea-87c9-3c3bcde45c4b">

