### PR TITLE
VOTE-2316: implemented FieldContainer for previous address state select

### DIFF
--- a/src/Components/FieldComponents/SelectField.jsx
+++ b/src/Components/FieldComponents/SelectField.jsx
@@ -9,8 +9,9 @@ function SelectField({ inputData, saveFieldData, fieldData }){
         className="radius-md" 
         aria-describedby={`${inputData.id}` + '_error'}
         name={inputData.id}
+        disabled={inputData.disabled}
         required={parseInt(inputData.required)}
-        value={fieldData[inputData.id]}
+        value={inputData.value}
         onChange={saveFieldData(inputData.id)}
         autoComplete="off"
         onInvalid={(e) => e.target.setCustomValidity(' ')}
@@ -19,7 +20,7 @@ function SelectField({ inputData, saveFieldData, fieldData }){
         <React.Fragment key=".0">                        
             <option value={''}>{inputData.stringContent}</option>
             {inputData.options.map((item, index) => (
-                <option key={index} value={item.value}>{item.key}</option>
+                <option key={item} value={item}>{item}</option>
             ))}
         </React.Fragment>
         </Select>

--- a/src/Components/Fields/PreviousAddressState.jsx
+++ b/src/Components/Fields/PreviousAddressState.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import FieldContainer from 'Components/FieldContainer';
+import {getField} from "Utils/fieldParser";
+
+function PreviousAddressState(props){
+    const uuid = "5a8a4b6d-c0f1-42f2-b991-8ea49a32e997";
+    const field = getField(props.fieldContent, uuid);
+    const stateField = getField(props.stateData.nvrf_fields, field.uuid);
+
+    return (
+        <FieldContainer
+            fieldType={'select'} inputData={{
+            id: field.nvrf_id,
+            dataTest: 'state',
+            required: stateField.required,
+            label: field.label,
+            options: props.statesList,
+            stringContent: props.stringContent.selectState,
+            error_msg: field.error_msg,
+            help_text: field.help_text,
+        }} saveFieldData={props.saveFieldData} fieldData={props.fieldData}/>
+    )
+}
+
+export default PreviousAddressState;

--- a/src/Components/Fields/PreviousAddressState.jsx
+++ b/src/Components/Fields/PreviousAddressState.jsx
@@ -10,7 +10,7 @@ function PreviousAddressState(props){
     return (
         <FieldContainer
             fieldType={'select'} inputData={{
-            id: field.nvrf_id,
+            id: 'prev_state',
             dataTest: 'state',
             required: stateField.required,
             label: field.label,

--- a/src/Views/FormPages/Addresses.jsx
+++ b/src/Views/FormPages/Addresses.jsx
@@ -1,6 +1,7 @@
 import { Label, TextInput, Checkbox, Grid } from '@trussworks/react-uswds';
 import StateSelector from 'Components/StateSelector';
 import CurrentApartmentNumber from 'Components/Fields/CurrentApartmentNumber';
+import PreviousAddressState from 'Components/Fields/PreviousAddressState';
 import React, { useState } from "react";
 import { restrictType, checkForErrors, toggleError } from 'Utils/ValidateField';
 import { sanitizeDOM } from 'Utils/JsonHelper';
@@ -416,7 +417,7 @@ function Addresses(props){
                             </Grid>
 
                         <Grid tablet={{ col: 4 }}>
-                            <div className="input-parent">
+                            {/* <div className="input-parent">
                                 <Label className="text-bold" htmlFor="prev-state">
                                     {prevStateField.label}{(addressFieldsState.required === "1") && <span className='required-text'>*</span>}
                                 </Label>
@@ -438,7 +439,8 @@ function Addresses(props){
                                 <span id="prev-state_error" role="alert" className='error-text' data-test="errorText">
                                     {prevStateField.error_msg}
                                 </span>
-                            </div>
+                            </div> */}
+                            <PreviousAddressState {...props} />
                         </Grid>
 
                             <Grid tablet={{ col: 4 }}>


### PR DESCRIPTION
## Jira Ticket

[VOTE-2316](https://cm-jira.usa.gov/browse/VOTE-2316)

implemented FieldContainer for current previous state select field.

## Testing

Load up the local site. 
Go to "Address and Location" section
Select "I have moved since I last registered in this state."
For the state select in previous address section, verify that:
1. The select value is changeable.
2. The state value shows up in the final form.