### PR TITLE
VOTE-2322: implemented FieldContainer for mailing zipcode

### DIFF
--- a/src/Components/FieldComponents/TextInputField.jsx
+++ b/src/Components/FieldComponents/TextInputField.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { TextInput } from '@trussworks/react-uswds';
-import { checkForErrors, toggleError } from 'Utils/ValidateField';
+import { restrictType, checkForErrors, toggleError } from 'Utils/ValidateField';
 
 function TextInputField({ inputData, saveFieldData, fieldData }){
     return (
@@ -12,9 +12,12 @@ function TextInputField({ inputData, saveFieldData, fieldData }){
         name={inputData.id}
         type="text"
         autoComplete="off"
+        minLength={inputData.minLength}
+        maxLength={inputData.maxLength}
         required={parseInt(inputData.required)}
         value={fieldData[inputData.id]}
         onChange={saveFieldData(inputData.id)}
+        onKeyDown={(e) => restrictType(e, inputData.inputType)}
         onBlur={(e) => toggleError(e, checkForErrors(e, 'check value exists'))}
         onInvalid={(e) => e.target.setCustomValidity(' ')}
         onInput={(e) => e.target.setCustomValidity('')}

--- a/src/Components/Fields/MailingZipCode.jsx
+++ b/src/Components/Fields/MailingZipCode.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import FieldContainer from 'Components/FieldContainer';
+import {getField} from "Utils/fieldParser";
+
+function MailingZipCode(props){
+    const uuid = "c4f9c0cb-2a25-4f1d-a93a-b06a19656cfe";
+    const field = getField(props.fieldContent, uuid);
+    const stateField = getField(props.stateData.nvrf_fields, field.uuid);
+
+    return (
+        <FieldContainer
+            fieldType={'text'} inputData={{
+            id: 'mail_zip_code',
+            dataTest: 'mailZip',
+            required: stateField.required,
+            label: field.label,
+            minLength: 5,
+            maxLength: 5,
+            inputType: 'number',
+            error_msg: field.error_msg,
+            help_text: field.help_text,
+        }} saveFieldData={props.saveFieldData} fieldData={props.fieldData}/>
+    )
+}
+
+export default MailingZipCode;

--- a/src/Views/FormPages/Addresses.jsx
+++ b/src/Views/FormPages/Addresses.jsx
@@ -1,6 +1,7 @@
 import { Label, TextInput, Checkbox, Grid } from '@trussworks/react-uswds';
 import StateSelector from 'Components/StateSelector';
 import CurrentApartmentNumber from 'Components/Fields/CurrentApartmentNumber';
+import MailingZipCode from 'Components/Fields/MailingZipCode';
 import React, { useState } from "react";
 import { restrictType, checkForErrors, toggleError } from 'Utils/ValidateField';
 import { sanitizeDOM } from 'Utils/JsonHelper';
@@ -35,7 +36,6 @@ function Addresses(props){
     const mailStreetAddressField = fields.find(item => item.uuid === "db9b1f7a-565b-4aad-8d7c-56a553c18326");
     const mailCityField = fields.find(item => item.uuid === "9a5baee7-357b-4e59-b4f2-fe2525c0fd6c");
     const mailStateField = fields.find(item => item.uuid === "b0f80289-6084-4723-8278-110fda210f0d");
-    const mailZipcodeField = fields.find(item => item.uuid === "c4f9c0cb-2a25-4f1d-a93a-b06a19656cfe");
 
     //Field requirements by state data
     const addressFieldsState = (nvrfStateFields.find(item => item.uuid === streetAddressField.uuid));
@@ -289,34 +289,7 @@ function Addresses(props){
                             </Grid>
 
                             <Grid tablet={{ col: true }}>
-                            <div className="input-parent">
-                                <Label className="text-bold" htmlFor="mail-zip-code">
-                                    {mailZipcodeField.label} {(addressFieldsState.required === "1") && <span className={'required-text'}>*</span>}
-                                </Label>
-                                <span className="usa-hint" id="mail-zip-hint">{zipcodeField.help_text}</span>
-                                <TextInput
-                                    data-test="mailZip"
-                                    id="mail-zip-code"
-                                    className="radius-md"
-                                    aria-describedby="mail-zip-code_error"
-                                    name="mail-zip"
-                                    value={props.fieldData.mail_zip_code}
-                                    type="text"
-                                    inputMode="numeric"
-                                    autoComplete="off"
-                                    required={(parseInt(addressFieldsState.required))}
-                                    minLength={5}
-                                    maxLength={5}
-                                    onChange={props.saveFieldData('mail_zip_code')}
-                                    onKeyDown={(e) => restrictType(e, 'number')}
-                                    onBlur={(e) => toggleError(e, checkForErrors(e, 'check value length'))}
-                                    onInvalid={(e) => e.target.setCustomValidity(' ')}
-                                    onInput={(e) => e.target.setCustomValidity('')}
-                                />
-                                <span id="mail-zip-code_error" role="alert" className='error-text' data-test="errorText">
-                                    {mailZipcodeField.error_msg}
-                                </span>
-                            </div>
+                                <MailingZipCode {...props} />
                             </Grid>
                         </Grid>
                     </>


### PR DESCRIPTION
## Jira Ticket

[VOTE-2322](https://cm-jira.usa.gov/browse/VOTE-2322)

implemented FieldContainer for mailing zipcode field.

## Testing

Load up the local site. 
Go to "Address and Location" section
Select "I get my mail at a different address from the one above."
For the zipcode field in mailing address section, verify that:
1. Only numbers can be typed
2. Only 5 digits can be typed
3. If required, and nothing is typed, cannot proceed on
4. The typed zipcode shows up in the final form