### PR TITLE
VOTE-2030: New instructions for address checkboxes

### DIFF
--- a/public/data/en/fields.json
+++ b/public/data/en/fields.json
@@ -1,769 +1,769 @@
 [
-    {
-    "uuid": "fd516f06-11bb-4c39-9080-735ed98100cc",
-    "lang": "en",
-    "nvrf_id": "choice_of_party",
-    "name": "Choice of party",
-    "label": "Enter the full name of the political party you wish to join or leave blank.",
-    "help_text": false,
-    "error_msg": "Choice of party must be filled out.",
-    "instructions": "<p>If you don't want to register with any political party, leave this field blank. You can still vote in general elections and open primary elections. But if your state holds a partisan primary election, you'll need to register with that party to vote in the partisan primary election.</p>",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "39fc63ad-ed5a-4ad5-98d3-aa236c96c61c",
-    "lang": "en",
-    "nvrf_id": "eligibility",
-    "name": "Confirm Eligibility*",
-    "label": "I am a U.S. citizen and meet the eligibility requirements listed above.",
-    "help_text": false,
-    "error_msg": "Confirm eligibility to continue.",
-    "instructions": "<p>If you do not agree with the above statement, do not continue with your voter registration.</p>",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "73e74065-fd5a-43c0-907c-268120e34bc3",
-    "lang": "en",
-    "nvrf_id": "confirm_info",
-    "name": "Confirm Information",
-    "label": "The information I have provided is true to the best of my knowledge under penalty of perjury.",
-    "help_text": false,
-    "error_msg": "Checkbox must be checked to continue.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "b7bdae35-e4be-4827-ae11-75d9c3e33bf0",
-    "lang": "en",
-    "nvrf_id": "first_name",
-    "name": "Current Legal Name: First Name",
-    "label": "First name",
-    "help_text": false,
-    "error_msg": "First name must be filled out.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "b306238a-a0f6-4bb8-b8ea-b3216ca75e0b",
-    "lang": "en",
-    "nvrf_id": "last_name",
-    "name": "Current Legal Name: Last Name",
-    "label": "Last name",
-    "help_text": false,
-    "error_msg": "Last name must be filled out.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "38020ec6-1b53-4227-99e5-feea5f60af07",
-    "lang": "en",
-    "nvrf_id": "middle_names",
-    "name": "Current Legal Name: Middle Name(s)",
-    "label": "Middle name(s)",
-    "help_text": "If you do not have a middle name, leave this field blank.",
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "eeff4fa1-00f2-474b-a791-1a4146dab11a",
-    "lang": "en",
-    "nvrf_id": "suffix",
-    "name": "Current Legal Name: Suffix",
-    "label": "Suffix",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": [
-    {
-    "key": "Jr.",
-    "value": "Jr."
-    },
-    {
-    "key": "Sr.",
-    "value": "Sr."
-    },
-    {
-    "key": "II",
-    "value": "II"
-    },
-    {
-    "key": "III",
-    "value": "III"
-    },
-    {
-    "key": "IV",
-    "value": "IV"
-    }
-    ]
-    },
-    {
-    "uuid": "86a544cd-cfe9-456a-b634-176a37a38d6d",
-    "lang": "en",
-    "nvrf_id": "salutation",
-    "name": "Current Legal Name: Title",
-    "label": "Title",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": [
-    {
-    "key": "Mr.",
-    "value": "Mr"
-    },
-    {
-    "key": "Miss",
-    "value": "Miss"
-    },
-    {
-    "key": "Ms.",
-    "value": "Ms"
-    },
-    {
-    "key": "Mrs.",
-    "value": "Mrs"
-    }
-    ]
-    },
-    {
-    "uuid": "d31b2a64-36a9-4bc6-a9d1-e68d2be8c211",
-    "lang": "en",
-    "nvrf_id": "dob",
-    "name": "Date of birth",
-    "label": "Date of birth",
-    "help_text": "MM/DD/YYYY",
-    "error_msg": "Date of birth must follow the format of 01 19 2000.",
-    "instructions": "<p>Be careful not to use today’s date.</p>",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "e7340274-ee3f-4d73-a967-c9d7c249be7b",
-    "lang": "en",
-    "nvrf_id": "diff_mailing_address",
-    "name": "Different Mailing Address",
-    "label": "I get my mail at a different address from the one above.",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "deba9b54-68ad-4ef1-8fb5-ee34e4ab8a49",
-    "lang": "en",
-    "nvrf_id": "apt_lot_number",
-    "name": "Home Address: Apt or Lot#",
-    "label": "Apartment or lot#",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "7e39a528-7518-40cb-b7b6-b635864dc117",
-    "lang": "en",
-    "nvrf_id": "city",
-    "name": "Home Address: City",
-    "label": "City",
-    "help_text": false,
-    "error_msg": "City name must be filled out.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "fe3a2a1d-34bd-472b-a843-3fa0635c4f40",
-    "lang": "en",
-    "nvrf_id": "mail_state",
-    "name": "Home Address: State",
-    "label": "State",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "6dcb9e8c-b40a-4cda-ba5c-06b98c3375f4",
-    "lang": "en",
-    "nvrf_id": "home_address",
-    "name": "Home Address: Street Address",
-    "label": "Street address",
-    "help_text": "1234 Main St.",
-    "error_msg": "Street address must be filled out.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "cdb06542-0cbd-4aa3-897f-83377b8d65e5",
-    "lang": "en",
-    "nvrf_id": "zip_code",
-    "name": "Home Address: ZIP",
-    "label": "ZIP code",
-    "help_text": "12345",
-    "error_msg": "ZIP code must be 5 digits.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "eb0ce8c5-b4f7-4aae-a0b9-84f0434d2edb",
-    "lang": "en",
-    "nvrf_id": "id_no_id",
-    "name": "ID: No valid ID",
-    "label": "I do not have a valid ID.",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "<p>\"None\" will appear on your completed form.</p>",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
-    "lang": "en",
-    "nvrf_id": "id_number",
-    "name": "ID: Social Security Number",
-    "label": "Social security number (last 4 digits)",
-    "help_text": "Provide the last 4 digits, for example (xxx-xx-1234)",
-    "error_msg": "Social security number must be 4 digits.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "fe8cf91e-f872-4ed7-848c-09c99a7d83c8",
-    "lang": "en",
-    "nvrf_id": "id_number",
-    "name": "ID: Social Security Number (Full)",
-    "label": "Full social security number",
-    "help_text": "Provide all 9 digits, for example (123-55-1234)",
-    "error_msg": "Social security number must be 9 digits.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "acd7f272-7a37-43f0-b51a-c78daf31e5fd",
-    "lang": "en",
-    "nvrf_id": "id_number",
-    "name": "ID: State Driver's License Number",
-    "label": "State driver's license number",
-    "help_text": false,
-    "error_msg": "ID number must be filled out.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
-    "lang": "en",
-    "nvrf_id": "id_number",
-    "name": "ID: State Non-driver ID",
-    "label": "State non-driver ID",
-    "help_text": false,
-    "error_msg": "ID number must be filled out.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "27d3a15c-f8c0-4035-9b0a-c2c0f674519c",
-    "lang": "en",
-    "nvrf_id": "id_type",
-    "name": "Identification Type",
-    "label": "Choose your identification type",
-    "help_text": false,
-    "error_msg": "Identification selection must be made from the list.",
-    "instructions": "<p>Select one option from the list.&nbsp;</p>",
-    "section_description": "",
-    "section_alert": "",
-    "options": [
-    {
-    "key": "default",
-    "value": "Select Identification"
-    },
-    {
-    "key": "driver-id-num",
-    "value": "State Driver's License Number"
-    },
-    {
-    "key": "state-id-num",
-    "value": "State Non-driver ID Number"
-    },
-    {
-    "key": "ssn",
-    "value": "Social Security Number (Last 4 digits)"
-    },
-    {
-    "key": "ssn-full",
-    "value": "Full Social Security Number"
-    },
-    {
-    "key": "none",
-    "value": "I do not have a valid ID"
-    }
-    ]
-    },
-    {
-    "uuid": "e87ca867-c5a5-4e42-98d5-d742edd03de3",
-    "lang": "en",
-    "nvrf_id": "changed_name",
-    "name": "Legally changed name",
-    "label": "I have legally changed my name since the last time I registered to vote.",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "f6634a79-49af-47a4-8e86-d74ba5b892b9",
-    "lang": "en",
-    "nvrf_id": "mail_apt_lot_number",
-    "name": "Mailing Address: Apt or Lot#",
-    "label": "Apartment or lot#",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "9a5baee7-357b-4e59-b4f2-fe2525c0fd6c",
-    "lang": "en",
-    "nvrf_id": "mail_city",
-    "name": "Mailing Address: City",
-    "label": "City",
-    "help_text": false,
-    "error_msg": "City name must be filled out.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "b0f80289-6084-4723-8278-110fda210f0d",
-    "lang": "en",
-    "nvrf_id": "mail_state",
-    "name": "Mailing Address: State",
-    "label": "State",
-    "help_text": false,
-    "error_msg": "Mailing state selection must be made.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "db9b1f7a-565b-4aad-8d7c-56a553c18326",
-    "lang": "en",
-    "nvrf_id": "mail_address",
-    "name": "Mailing Address: Street Address",
-    "label": "Street address",
-    "help_text": false,
-    "error_msg": "Mailing street address must be filled out.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "c4f9c0cb-2a25-4f1d-a93a-b06a19656cfe",
-    "lang": "en",
-    "nvrf_id": "mail_zip_code",
-    "name": "Mailing Address: ZIP Code",
-    "label": "ZIP code",
-    "help_text": "12345",
-    "error_msg": "ZIP code must be 5 digits.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "c3011c62-d174-420c-817a-bffbcd45687a",
-    "lang": "en",
-    "nvrf_id": "moved",
-    "name": "Moved",
-    "label": "I have moved since I last registered in this state.",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "f282e541-7ca8-4c22-8d87-d4cff56e22e5",
-    "lang": "en",
-    "nvrf_id": "first_name_2",
-    "name": "Name Before Legally Changed: First Name",
-    "label": "First name",
-    "help_text": false,
-    "error_msg": "First name must be filled out.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "42de34cc-ebf3-4d8e-8873-2571063b62c0",
-    "lang": "en",
-    "nvrf_id": "last_name_2",
-    "name": "Name Before Legally Changed: Last Name",
-    "label": "Last name",
-    "help_text": false,
-    "error_msg": "Last name must be filled out.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "a4919026-91ac-4e05-a75f-e2df479abd76",
-    "lang": "en",
-    "nvrf_id": "middle_names_2",
-    "name": "Name Before Legally Changed: Middle Name(s)",
-    "label": "Middle name(s)",
-    "help_text": "If you do not have a middle name, you may leave this field blank.",
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "09cb2989-d302-4a01-bb3a-33173adcffb2",
-    "lang": "en",
-    "nvrf_id": "suffix_2",
-    "name": "Name Before Legally Changed: Suffix",
-    "label": "Suffix",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": [
-    {
-    "key": "Jr.",
-    "value": "Jr."
-    },
-    {
-    "key": "Sr.",
-    "value": "Sr."
-    },
-    {
-    "key": "II",
-    "value": "II"
-    },
-    {
-    "key": "III",
-    "value": "III"
-    },
-    {
-    "key": "IV",
-    "value": "IV"
-    }
-    ]
-    },
-    {
-    "uuid": "34d2669a-d30b-4001-b897-280fe71b3cb0",
-    "lang": "en",
-    "nvrf_id": "title_2",
-    "name": "Name Before Legally Changed: Title",
-    "label": "Title",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": [
-    {
-    "key": "Mr.",
-    "value": "Mr"
-    },
-    {
-    "key": "Miss",
-    "value": "Miss"
-    },
-    {
-    "key": "Ms.",
-    "value": "Ms"
-    },
-    {
-    "key": "Mrs.",
-    "value": "Mrs"
-    }
-    ]
-    },
-    {
-    "uuid": "35c2b98d-477c-45f3-9f93-f720406080f1",
-    "lang": "en",
-    "nvrf_id": "no_street_address",
-    "name": "No Street Address",
-    "label": "I do not have a street address.",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "2d61b54a-e568-410f-825a-0ca82dfd3f63",
-    "lang": "en",
-    "nvrf_id": "telephone_number",
-    "name": "Phone Number",
-    "label": "Phone number",
-    "help_text": "(123) 456-7890",
-    "error_msg": "Phone number must be 10 digits.",
-    "instructions": "<p>You do not have to provide your telephone number. This is used if election officials have questions about your form.</p>",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "c8e2ff17-fb1f-4971-a664-ffbb557b305a",
-    "lang": "en",
-    "nvrf_id": "prev_apt_lot_number",
-    "name": "Previous Home Address: Apt or Lot#",
-    "label": "Apartment or lot#",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "44bf0a5c-adba-4b47-bc99-cc46cede5e80",
-    "lang": "en",
-    "nvrf_id": "prev_city",
-    "name": "Previous Home Address: City",
-    "label": "City",
-    "help_text": false,
-    "error_msg": "City name must be filled out.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "5a8a4b6d-c0f1-42f2-b991-8ea49a32e997",
-    "lang": "en",
-    "nvrf_id": "prev_state",
-    "name": "Previous Home Address: State",
-    "label": "State",
-    "help_text": false,
-    "error_msg": "Previous state selection must be made.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "c037a3ea-86b7-4661-ad28-c7228f1e682b",
-    "lang": "en",
-    "nvrf_id": "prev_address",
-    "name": "Previous Home Address: Street Address",
-    "label": "Street address",
-    "help_text": false,
-    "error_msg": "Previous street address must be filled out.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "49a90983-1925-438f-8271-88f39bf19bf1",
-    "lang": "en",
-    "nvrf_id": "prev_zip_code",
-    "name": "Previous Home Address: ZIP Code",
-    "label": "ZIP code",
-    "help_text": "124345",
-    "error_msg": "ZIP code must be 5 digits.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "2bfff6c6-6782-4b14-ac45-642efd278f6a",
-    "lang": "en",
-    "nvrf_id": "race_ethnic_group",
-    "name": "Race or Ethnic Group",
-    "label": "Race or ethnic group",
-    "help_text": false,
-    "error_msg": "Race or ethnic group must be filled out.",
-    "instructions": "<p>Select the choice that best describes you from the list.</p>",
-    "section_description": "",
-    "section_alert": "",
-    "options": [
-    {
-    "key": "American Indian or Alaskan Native",
-    "value": "American Indian or Alaskan Native"
-    },
-    {
-    "key": "Asian or Pacific Islander",
-    "value": "Asian or Pacific Islander"
-    },
-    {
-    "key": "Black, not of Hispanic Origin",
-    "value": "Black, not of Hispanic Origin"
-    },
-    {
-    "key": "Hispanic",
-    "value": "Hispanic"
-    },
-    {
-    "key": "Multi-racial",
-    "value": "Multi-racial"
-    },
-    {
-    "key": "White, not of Hispanic Origin",
-    "value": "White, not of Hispanic Origin"
-    },
-    {
-    "key": "Other",
-    "value": "Other"
-    }
-    ]
-    },
-    {
-    "uuid": "8dda085c-edf3-4678-b30a-0a457699be46",
-    "lang": "en",
-    "nvrf_id": "null",
-    "name": "Section: Current Legal Name",
-    "label": "What is your legal name?",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "<p>Using the name on your driver’s license or other non-driver ID is recommended.</p>",
-    "section_alert": "<p>Enter your full legal name. Be sure to include your first, middle, and last name. Do not use nicknames or initials.</p>",
-    "options": []
-    },
-    {
-    "uuid": "63552bb6-6afb-46e1-8148-860242917a22",
-    "lang": "en",
-    "nvrf_id": "null",
-    "name": "Section: Home Address",
-    "label": "What is your home address?",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "<p>Enter your home address (legal address). Do not put your mailing address here if it’s different from your home address. Do not use a post office box or rural route without a box number.</p>",
-    "options": []
-    },
-    {
-    "uuid": "1a856408-6fb2-4b09-b05a-8d8ee9eb9bb5",
-    "lang": "en",
-    "nvrf_id": "null",
-    "name": "Section: Mailing Address",
-    "label": "What is your mailing address?",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "<p>Enter the address where you receive mail so voter registration materials can be sent to you. You can use a post office box number.</p>",
-    "section_alert": "<p>If you live in a rural area but do not have a street address, or if you have no address, you must enter an address where you can be reached by mail. You will have the opportunity to show where you live on a map when you print out your form.</p>",
-    "options": []
-    },
-    {
-    "uuid": "6dd20906-654e-427e-bb82-1e62aee9ed72",
-    "lang": "en",
-    "nvrf_id": "null",
-    "name": "Section: Moved and No Street Address",
-    "label": "Check one or both boxes if they apply to you.",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "af4e6259-5b07-4955-9d28-254504ec9df8",
-    "lang": "en",
-    "nvrf_id": "null",
-    "name": "Section: Name Before Legally Changed",
-    "label": "What was your name before you legally changed it?",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "3724c7cd-5ec7-4e3e-85cd-db0cab63e99b",
-    "lang": "en",
-    "nvrf_id": "null",
-    "name": "Section: No Street Address",
-    "label": "Check this box if it applies to you.",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "023fda0f-e8bd-4654-ab5c-46f44a0b7bd6",
-    "lang": "en",
-    "nvrf_id": "null",
-    "name": "Section: Previous Home Address",
-    "label": "What was the address where you were registered before?",
-    "help_text": false,
-    "error_msg": false,
-    "instructions": "",
-    "section_description": "<p>If you were registered before but this is the first time you are registering from this address, please tell us the address where you were registered before. Please give us as much of the address as you can remember.</p>",
-    "section_alert": "",
-    "options": []
-    },
-    {
-    "uuid": "7231330d-523b-4e22-b282-b9f98ee20ef2",
-    "lang": "en",
-    "nvrf_id": "state",
-    "name": "State Selection",
-    "label": "I live in:*",
-    "help_text": false,
-    "error_msg": "State or territory selection must be made.",
-    "instructions": "",
-    "section_description": "",
-    "section_alert": "",
-    "options": []
-    }
+  {
+  "uuid": "fd516f06-11bb-4c39-9080-735ed98100cc",
+  "lang": "en",
+  "nvrf_id": "choice_of_party",
+  "name": "Choice of party",
+  "label": "Enter the full name of the political party you wish to join or leave blank.",
+  "help_text": false,
+  "error_msg": "Choice of party must be filled out.",
+  "instructions": "<p>If you don't want to register with any political party, leave this field blank. You can still vote in general elections and open primary elections. But if your state holds a partisan primary election, you'll need to register with that party to vote in the partisan primary election.</p>",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "39fc63ad-ed5a-4ad5-98d3-aa236c96c61c",
+  "lang": "en",
+  "nvrf_id": "eligibility",
+  "name": "Confirm Eligibility*",
+  "label": "I am a U.S. citizen and meet the eligibility requirements listed above.",
+  "help_text": false,
+  "error_msg": "Confirm eligibility to continue.",
+  "instructions": "<p>If you do not agree with the above statement, do not continue with your voter registration.</p>",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "73e74065-fd5a-43c0-907c-268120e34bc3",
+  "lang": "en",
+  "nvrf_id": "confirm_info",
+  "name": "Confirm Information",
+  "label": "The information I have provided is true to the best of my knowledge under penalty of perjury.",
+  "help_text": false,
+  "error_msg": "Checkbox must be checked to continue.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "b7bdae35-e4be-4827-ae11-75d9c3e33bf0",
+  "lang": "en",
+  "nvrf_id": "first_name",
+  "name": "Current Legal Name: First Name",
+  "label": "First name",
+  "help_text": false,
+  "error_msg": "First name must be filled out.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "b306238a-a0f6-4bb8-b8ea-b3216ca75e0b",
+  "lang": "en",
+  "nvrf_id": "last_name",
+  "name": "Current Legal Name: Last Name",
+  "label": "Last name",
+  "help_text": false,
+  "error_msg": "Last name must be filled out.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "38020ec6-1b53-4227-99e5-feea5f60af07",
+  "lang": "en",
+  "nvrf_id": "middle_names",
+  "name": "Current Legal Name: Middle Name(s)",
+  "label": "Middle name(s)",
+  "help_text": "If you do not have a middle name, leave this field blank.",
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "eeff4fa1-00f2-474b-a791-1a4146dab11a",
+  "lang": "en",
+  "nvrf_id": "suffix",
+  "name": "Current Legal Name: Suffix",
+  "label": "Suffix",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": [
+  {
+  "key": "Jr.",
+  "value": "Jr."
+  },
+  {
+  "key": "Sr.",
+  "value": "Sr."
+  },
+  {
+  "key": "II",
+  "value": "II"
+  },
+  {
+  "key": "III",
+  "value": "III"
+  },
+  {
+  "key": "IV",
+  "value": "IV"
+  }
+  ]
+  },
+  {
+  "uuid": "86a544cd-cfe9-456a-b634-176a37a38d6d",
+  "lang": "en",
+  "nvrf_id": "salutation",
+  "name": "Current Legal Name: Title",
+  "label": "Title",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": [
+  {
+  "key": "Mr.",
+  "value": "Mr"
+  },
+  {
+  "key": "Miss",
+  "value": "Miss"
+  },
+  {
+  "key": "Ms.",
+  "value": "Ms"
+  },
+  {
+  "key": "Mrs.",
+  "value": "Mrs"
+  }
+  ]
+  },
+  {
+  "uuid": "d31b2a64-36a9-4bc6-a9d1-e68d2be8c211",
+  "lang": "en",
+  "nvrf_id": "dob",
+  "name": "Date of birth",
+  "label": "Date of birth",
+  "help_text": "MM/DD/YYYY",
+  "error_msg": "Date of birth must follow the format of 01 19 2000.",
+  "instructions": "<p>Be careful not to use today’s date.</p>",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "e7340274-ee3f-4d73-a967-c9d7c249be7b",
+  "lang": "en",
+  "nvrf_id": "diff_mailing_address",
+  "name": "Different Mailing Address",
+  "label": "I get my mail at a different address from the one above.",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "deba9b54-68ad-4ef1-8fb5-ee34e4ab8a49",
+  "lang": "en",
+  "nvrf_id": "apt_lot_number",
+  "name": "Home Address: Apt or Lot#",
+  "label": "Apartment or lot#",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "7e39a528-7518-40cb-b7b6-b635864dc117",
+  "lang": "en",
+  "nvrf_id": "city",
+  "name": "Home Address: City",
+  "label": "City",
+  "help_text": false,
+  "error_msg": "City name must be filled out.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "fe3a2a1d-34bd-472b-a843-3fa0635c4f40",
+  "lang": "en",
+  "nvrf_id": "mail_state",
+  "name": "Home Address: State",
+  "label": "State",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "6dcb9e8c-b40a-4cda-ba5c-06b98c3375f4",
+  "lang": "en",
+  "nvrf_id": "home_address",
+  "name": "Home Address: Street Address",
+  "label": "Street address",
+  "help_text": "1234 Main St.",
+  "error_msg": "Street address must be filled out.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "cdb06542-0cbd-4aa3-897f-83377b8d65e5",
+  "lang": "en",
+  "nvrf_id": "zip_code",
+  "name": "Home Address: ZIP",
+  "label": "ZIP code",
+  "help_text": "12345",
+  "error_msg": "ZIP code must be 5 digits.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "eb0ce8c5-b4f7-4aae-a0b9-84f0434d2edb",
+  "lang": "en",
+  "nvrf_id": "id_no_id",
+  "name": "ID: No valid ID",
+  "label": "I do not have a valid ID.",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "<p>\"None\" will appear on your completed form.</p>",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
+  "lang": "en",
+  "nvrf_id": "id_number",
+  "name": "ID: Social Security Number",
+  "label": "Social security number (last 4 digits)",
+  "help_text": "Provide the last 4 digits, for example (xxx-xx-1234)",
+  "error_msg": "Social security number must be 4 digits.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "fe8cf91e-f872-4ed7-848c-09c99a7d83c8",
+  "lang": "en",
+  "nvrf_id": "id_number",
+  "name": "ID: Social Security Number (Full)",
+  "label": "Full social security number",
+  "help_text": "Provide all 9 digits, for example (123-55-1234)",
+  "error_msg": "Social security number must be 9 digits.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "acd7f272-7a37-43f0-b51a-c78daf31e5fd",
+  "lang": "en",
+  "nvrf_id": "id_number",
+  "name": "ID: State Driver's License Number",
+  "label": "State driver's license number",
+  "help_text": false,
+  "error_msg": "ID number must be filled out.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
+  "lang": "en",
+  "nvrf_id": "id_number",
+  "name": "ID: State Non-driver ID",
+  "label": "State non-driver ID",
+  "help_text": false,
+  "error_msg": "ID number must be filled out.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "27d3a15c-f8c0-4035-9b0a-c2c0f674519c",
+  "lang": "en",
+  "nvrf_id": "id_type",
+  "name": "Identification Type",
+  "label": "Choose your identification type",
+  "help_text": false,
+  "error_msg": "Identification selection must be made from the list.",
+  "instructions": "<p>Select one option from the list.&nbsp;</p>",
+  "section_description": "",
+  "section_alert": "",
+  "options": [
+  {
+  "key": "default",
+  "value": "Select Identification"
+  },
+  {
+  "key": "driver-id-num",
+  "value": "State Driver's License Number"
+  },
+  {
+  "key": "state-id-num",
+  "value": "State Non-driver ID Number"
+  },
+  {
+  "key": "ssn",
+  "value": "Social Security Number (Last 4 digits)"
+  },
+  {
+  "key": "ssn-full",
+  "value": "Full Social Security Number"
+  },
+  {
+  "key": "none",
+  "value": "I do not have a valid ID"
+  }
+  ]
+  },
+  {
+  "uuid": "e87ca867-c5a5-4e42-98d5-d742edd03de3",
+  "lang": "en",
+  "nvrf_id": "changed_name",
+  "name": "Legally changed name",
+  "label": "I have legally changed my name since the last time I registered to vote.",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "f6634a79-49af-47a4-8e86-d74ba5b892b9",
+  "lang": "en",
+  "nvrf_id": "mail_apt_lot_number",
+  "name": "Mailing Address: Apt or Lot#",
+  "label": "Apartment or lot#",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "9a5baee7-357b-4e59-b4f2-fe2525c0fd6c",
+  "lang": "en",
+  "nvrf_id": "mail_city",
+  "name": "Mailing Address: City",
+  "label": "City",
+  "help_text": false,
+  "error_msg": "City name must be filled out.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "b0f80289-6084-4723-8278-110fda210f0d",
+  "lang": "en",
+  "nvrf_id": "mail_state",
+  "name": "Mailing Address: State",
+  "label": "State",
+  "help_text": false,
+  "error_msg": "Mailing state selection must be made.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "db9b1f7a-565b-4aad-8d7c-56a553c18326",
+  "lang": "en",
+  "nvrf_id": "mail_address",
+  "name": "Mailing Address: Street Address",
+  "label": "Street address",
+  "help_text": false,
+  "error_msg": "Mailing street address must be filled out.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "c4f9c0cb-2a25-4f1d-a93a-b06a19656cfe",
+  "lang": "en",
+  "nvrf_id": "mail_zip_code",
+  "name": "Mailing Address: ZIP Code",
+  "label": "ZIP code",
+  "help_text": "12345",
+  "error_msg": "ZIP code must be 5 digits.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "c3011c62-d174-420c-817a-bffbcd45687a",
+  "lang": "en",
+  "nvrf_id": "moved",
+  "name": "Moved",
+  "label": "I have moved since I last registered in this state.",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "f282e541-7ca8-4c22-8d87-d4cff56e22e5",
+  "lang": "en",
+  "nvrf_id": "first_name_2",
+  "name": "Name Before Legally Changed: First Name",
+  "label": "First name",
+  "help_text": false,
+  "error_msg": "First name must be filled out.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "42de34cc-ebf3-4d8e-8873-2571063b62c0",
+  "lang": "en",
+  "nvrf_id": "last_name_2",
+  "name": "Name Before Legally Changed: Last Name",
+  "label": "Last name",
+  "help_text": false,
+  "error_msg": "Last name must be filled out.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "a4919026-91ac-4e05-a75f-e2df479abd76",
+  "lang": "en",
+  "nvrf_id": "middle_names_2",
+  "name": "Name Before Legally Changed: Middle Name(s)",
+  "label": "Middle name(s)",
+  "help_text": "If you do not have a middle name, you may leave this field blank.",
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "09cb2989-d302-4a01-bb3a-33173adcffb2",
+  "lang": "en",
+  "nvrf_id": "suffix_2",
+  "name": "Name Before Legally Changed: Suffix",
+  "label": "Suffix",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": [
+  {
+  "key": "Jr.",
+  "value": "Jr."
+  },
+  {
+  "key": "Sr.",
+  "value": "Sr."
+  },
+  {
+  "key": "II",
+  "value": "II"
+  },
+  {
+  "key": "III",
+  "value": "III"
+  },
+  {
+  "key": "IV",
+  "value": "IV"
+  }
+  ]
+  },
+  {
+  "uuid": "34d2669a-d30b-4001-b897-280fe71b3cb0",
+  "lang": "en",
+  "nvrf_id": "title_2",
+  "name": "Name Before Legally Changed: Title",
+  "label": "Title",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": [
+  {
+  "key": "Mr.",
+  "value": "Mr"
+  },
+  {
+  "key": "Miss",
+  "value": "Miss"
+  },
+  {
+  "key": "Ms.",
+  "value": "Ms"
+  },
+  {
+  "key": "Mrs.",
+  "value": "Mrs"
+  }
+  ]
+  },
+  {
+  "uuid": "35c2b98d-477c-45f3-9f93-f720406080f1",
+  "lang": "en",
+  "nvrf_id": "no_street_address",
+  "name": "No Street Address",
+  "label": "I do not have a street address.",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "2d61b54a-e568-410f-825a-0ca82dfd3f63",
+  "lang": "en",
+  "nvrf_id": "telephone_number",
+  "name": "Phone Number",
+  "label": "Phone number",
+  "help_text": "(123) 456-7890",
+  "error_msg": "Phone number must be 10 digits.",
+  "instructions": "<p>You do not have to provide your telephone number. This is used if election officials have questions about your form.</p>",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "c8e2ff17-fb1f-4971-a664-ffbb557b305a",
+  "lang": "en",
+  "nvrf_id": "prev_apt_lot_number",
+  "name": "Previous Home Address: Apt or Lot#",
+  "label": "Apartment or lot#",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "44bf0a5c-adba-4b47-bc99-cc46cede5e80",
+  "lang": "en",
+  "nvrf_id": "prev_city",
+  "name": "Previous Home Address: City",
+  "label": "City",
+  "help_text": false,
+  "error_msg": "City name must be filled out.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "5a8a4b6d-c0f1-42f2-b991-8ea49a32e997",
+  "lang": "en",
+  "nvrf_id": "prev_state",
+  "name": "Previous Home Address: State",
+  "label": "State",
+  "help_text": false,
+  "error_msg": "Previous state selection must be made.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "c037a3ea-86b7-4661-ad28-c7228f1e682b",
+  "lang": "en",
+  "nvrf_id": "prev_address",
+  "name": "Previous Home Address: Street Address",
+  "label": "Street address",
+  "help_text": false,
+  "error_msg": "Previous street address must be filled out.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "49a90983-1925-438f-8271-88f39bf19bf1",
+  "lang": "en",
+  "nvrf_id": "prev_zip_code",
+  "name": "Previous Home Address: ZIP Code",
+  "label": "ZIP code",
+  "help_text": "124345",
+  "error_msg": "ZIP code must be 5 digits.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "2bfff6c6-6782-4b14-ac45-642efd278f6a",
+  "lang": "en",
+  "nvrf_id": "race_ethnic_group",
+  "name": "Race or Ethnic Group",
+  "label": "Race or ethnic group",
+  "help_text": false,
+  "error_msg": "Race or ethnic group must be filled out.",
+  "instructions": "<p>Select the choice that best describes you from the list.</p>",
+  "section_description": "",
+  "section_alert": "",
+  "options": [
+  {
+  "key": "American Indian or Alaskan Native",
+  "value": "American Indian or Alaskan Native"
+  },
+  {
+  "key": "Asian or Pacific Islander",
+  "value": "Asian or Pacific Islander"
+  },
+  {
+  "key": "Black, not of Hispanic Origin",
+  "value": "Black, not of Hispanic Origin"
+  },
+  {
+  "key": "Hispanic",
+  "value": "Hispanic"
+  },
+  {
+  "key": "Multi-racial",
+  "value": "Multi-racial"
+  },
+  {
+  "key": "White, not of Hispanic Origin",
+  "value": "White, not of Hispanic Origin"
+  },
+  {
+  "key": "Other",
+  "value": "Other"
+  }
+  ]
+  },
+  {
+  "uuid": "8dda085c-edf3-4678-b30a-0a457699be46",
+  "lang": "en",
+  "nvrf_id": "null",
+  "name": "Section: Current Legal Name",
+  "label": "What is your legal name?",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "<p>Using the name on your driver’s license or other non-driver ID is recommended.</p>",
+  "section_alert": "<p>Enter your full legal name. Be sure to include your first, middle, and last name. Do not use nicknames or initials.</p>",
+  "options": []
+  },
+  {
+  "uuid": "63552bb6-6afb-46e1-8148-860242917a22",
+  "lang": "en",
+  "nvrf_id": "null",
+  "name": "Section: Home Address",
+  "label": "What is your home address?",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "<p>Enter your home address (legal address). Do not put your mailing address here if it’s different from your home address. Do not use a post office box or rural route without a box number.</p>",
+  "options": []
+  },
+  {
+  "uuid": "1a856408-6fb2-4b09-b05a-8d8ee9eb9bb5",
+  "lang": "en",
+  "nvrf_id": "null",
+  "name": "Section: Mailing Address",
+  "label": "What is your mailing address?",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "<p>Enter the address where you receive mail so voter registration materials can be sent to you. You can use a post office box number.</p>",
+  "section_alert": "<p>If you live in a rural area but do not have a street address, or if you have no address, you must enter an address where you can be reached by mail. You will have the opportunity to show where you live on a map when you print out your form.</p>",
+  "options": []
+  },
+  {
+  "uuid": "6dd20906-654e-427e-bb82-1e62aee9ed72",
+  "lang": "en",
+  "nvrf_id": "null",
+  "name": "Section: Moved and No Street Address",
+  "label": "Check one or both boxes if they apply to you.",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "af4e6259-5b07-4955-9d28-254504ec9df8",
+  "lang": "en",
+  "nvrf_id": "null",
+  "name": "Section: Name Before Legally Changed",
+  "label": "What was your name before you legally changed it?",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "3724c7cd-5ec7-4e3e-85cd-db0cab63e99b",
+  "lang": "en",
+  "nvrf_id": "null",
+  "name": "Section: No Street Address",
+  "label": "Check this box if it applies to you.",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "023fda0f-e8bd-4654-ab5c-46f44a0b7bd6",
+  "lang": "en",
+  "nvrf_id": "null",
+  "name": "Section: Previous Home Address",
+  "label": "What was the address where you were registered before?",
+  "help_text": false,
+  "error_msg": false,
+  "instructions": "",
+  "section_description": "<p>If you were registered before but this is the first time you are registering from this address, please tell us the address where you were registered before. Please give us as much of the address as you can remember.</p>",
+  "section_alert": "",
+  "options": []
+  },
+  {
+  "uuid": "7231330d-523b-4e22-b282-b9f98ee20ef2",
+  "lang": "en",
+  "nvrf_id": "state",
+  "name": "State Selection",
+  "label": "I live in:*",
+  "help_text": false,
+  "error_msg": "State or territory selection must be made.",
+  "instructions": "",
+  "section_description": "",
+  "section_alert": "",
+  "options": []
+  }
 ]

--- a/public/data/en/fields.json
+++ b/public/data/en/fields.json
@@ -1,5 +1,5 @@
 [
-  {
+    {
     "uuid": "fd516f06-11bb-4c39-9080-735ed98100cc",
     "lang": "en",
     "nvrf_id": "choice_of_party",
@@ -7,12 +7,12 @@
     "label": "Enter the full name of the political party you wish to join or leave blank.",
     "help_text": false,
     "error_msg": "Choice of party must be filled out.",
-    "instructions": "\u003Cp\u003EIf you don\u0027t want to register with any political party, leave this field blank. You can still vote in general elections and open primary elections. But if your state holds a partisan primary election, you\u0027ll need to register with that party to vote in the partisan primary election.\u003C\/p\u003E",
+    "instructions": "<p>If you don't want to register with any political party, leave this field blank. You can still vote in general elections and open primary elections. But if your state holds a partisan primary election, you'll need to register with that party to vote in the partisan primary election.</p>",
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "39fc63ad-ed5a-4ad5-98d3-aa236c96c61c",
     "lang": "en",
     "nvrf_id": "eligibility",
@@ -20,12 +20,12 @@
     "label": "I am a U.S. citizen and meet the eligibility requirements listed above.",
     "help_text": false,
     "error_msg": "Confirm eligibility to continue.",
-    "instructions": "\u003Cp\u003EIf you do not agree with the above statement, do not continue with your voter registration.\u003C\/p\u003E",
+    "instructions": "<p>If you do not agree with the above statement, do not continue with your voter registration.</p>",
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "73e74065-fd5a-43c0-907c-268120e34bc3",
     "lang": "en",
     "nvrf_id": "confirm_info",
@@ -37,8 +37,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "b7bdae35-e4be-4827-ae11-75d9c3e33bf0",
     "lang": "en",
     "nvrf_id": "first_name",
@@ -50,8 +50,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "b306238a-a0f6-4bb8-b8ea-b3216ca75e0b",
     "lang": "en",
     "nvrf_id": "last_name",
@@ -63,8 +63,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "38020ec6-1b53-4227-99e5-feea5f60af07",
     "lang": "en",
     "nvrf_id": "middle_names",
@@ -76,8 +76,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "eeff4fa1-00f2-474b-a791-1a4146dab11a",
     "lang": "en",
     "nvrf_id": "suffix",
@@ -89,29 +89,29 @@
     "section_description": "",
     "section_alert": "",
     "options": [
-      {
-        "key": "Jr.",
-        "value": "Jr."
-      },
-      {
-        "key": "Sr.",
-        "value": "Sr."
-      },
-      {
-        "key": "II",
-        "value": "II"
-      },
-      {
-        "key": "III",
-        "value": "III"
-      },
-      {
-        "key": "IV",
-        "value": "IV"
-      }
+    {
+    "key": "Jr.",
+    "value": "Jr."
+    },
+    {
+    "key": "Sr.",
+    "value": "Sr."
+    },
+    {
+    "key": "II",
+    "value": "II"
+    },
+    {
+    "key": "III",
+    "value": "III"
+    },
+    {
+    "key": "IV",
+    "value": "IV"
+    }
     ]
-  },
-  {
+    },
+    {
     "uuid": "86a544cd-cfe9-456a-b634-176a37a38d6d",
     "lang": "en",
     "nvrf_id": "salutation",
@@ -123,38 +123,38 @@
     "section_description": "",
     "section_alert": "",
     "options": [
-      {
-        "key": "Mr.",
-        "value": "Mr"
-      },
-      {
-        "key": "Miss",
-        "value": "Miss"
-      },
-      {
-        "key": "Ms.",
-        "value": "Ms"
-      },
-      {
-        "key": "Mrs.",
-        "value": "Mrs"
-      }
+    {
+    "key": "Mr.",
+    "value": "Mr"
+    },
+    {
+    "key": "Miss",
+    "value": "Miss"
+    },
+    {
+    "key": "Ms.",
+    "value": "Ms"
+    },
+    {
+    "key": "Mrs.",
+    "value": "Mrs"
+    }
     ]
-  },
-  {
+    },
+    {
     "uuid": "d31b2a64-36a9-4bc6-a9d1-e68d2be8c211",
     "lang": "en",
     "nvrf_id": "dob",
     "name": "Date of birth",
     "label": "Date of birth",
-    "help_text": "MM\/DD\/YYYY",
+    "help_text": "MM/DD/YYYY",
     "error_msg": "Date of birth must follow the format of 01 19 2000.",
-    "instructions": "\u003Cp\u003EBe careful not to use today\u2019s date.\u003C\/p\u003E",
+    "instructions": "<p>Be careful not to use today’s date.</p>",
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "e7340274-ee3f-4d73-a967-c9d7c249be7b",
     "lang": "en",
     "nvrf_id": "diff_mailing_address",
@@ -166,8 +166,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "deba9b54-68ad-4ef1-8fb5-ee34e4ab8a49",
     "lang": "en",
     "nvrf_id": "apt_lot_number",
@@ -179,8 +179,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "7e39a528-7518-40cb-b7b6-b635864dc117",
     "lang": "en",
     "nvrf_id": "city",
@@ -192,8 +192,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "fe3a2a1d-34bd-472b-a843-3fa0635c4f40",
     "lang": "en",
     "nvrf_id": "mail_state",
@@ -205,8 +205,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "6dcb9e8c-b40a-4cda-ba5c-06b98c3375f4",
     "lang": "en",
     "nvrf_id": "home_address",
@@ -218,8 +218,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "cdb06542-0cbd-4aa3-897f-83377b8d65e5",
     "lang": "en",
     "nvrf_id": "zip_code",
@@ -231,8 +231,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "eb0ce8c5-b4f7-4aae-a0b9-84f0434d2edb",
     "lang": "en",
     "nvrf_id": "id_no_id",
@@ -240,12 +240,12 @@
     "label": "I do not have a valid ID.",
     "help_text": false,
     "error_msg": false,
-    "instructions": "\u003Cp\u003E\u0022None\u0022 will appear on your completed form.\u003C\/p\u003E",
+    "instructions": "<p>\"None\" will appear on your completed form.</p>",
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "1e030197-52e7-426e-923c-b67ef521ae3b",
     "lang": "en",
     "nvrf_id": "id_number",
@@ -257,8 +257,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "fe8cf91e-f872-4ed7-848c-09c99a7d83c8",
     "lang": "en",
     "nvrf_id": "id_number",
@@ -270,21 +270,21 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "acd7f272-7a37-43f0-b51a-c78daf31e5fd",
     "lang": "en",
     "nvrf_id": "id_number",
-    "name": "ID: State Driver\u0027s License Number",
-    "label": "State driver\u0027s license number",
+    "name": "ID: State Driver's License Number",
+    "label": "State driver's license number",
     "help_text": false,
     "error_msg": "ID number must be filled out.",
     "instructions": "",
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "e2da00fa-0f1b-4e98-9472-c00649266eb4",
     "lang": "en",
     "nvrf_id": "id_number",
@@ -296,8 +296,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "27d3a15c-f8c0-4035-9b0a-c2c0f674519c",
     "lang": "en",
     "nvrf_id": "id_type",
@@ -305,37 +305,37 @@
     "label": "Choose your identification type",
     "help_text": false,
     "error_msg": "Identification selection must be made from the list.",
-    "instructions": "\u003Cp\u003ESelect one option from the list.\u0026nbsp;\u003C\/p\u003E",
+    "instructions": "<p>Select one option from the list.&nbsp;</p>",
     "section_description": "",
     "section_alert": "",
     "options": [
-      {
-        "key": "default",
-        "value": "Select Identification"
-      },
-      {
-        "key": "driver-id-num",
-        "value": "State Driver\u0027s License Number"
-      },
-      {
-        "key": "state-id-num",
-        "value": "State Non-driver ID Number"
-      },
-      {
-        "key": "ssn",
-        "value": "Social Security Number (Last 4 digits)"
-      },
-      {
-        "key": "ssn-full",
-        "value": "Full Social Security Number"
-      },
-      {
-        "key": "none",
-        "value": "I do not have a valid ID"
-      }
+    {
+    "key": "default",
+    "value": "Select Identification"
+    },
+    {
+    "key": "driver-id-num",
+    "value": "State Driver's License Number"
+    },
+    {
+    "key": "state-id-num",
+    "value": "State Non-driver ID Number"
+    },
+    {
+    "key": "ssn",
+    "value": "Social Security Number (Last 4 digits)"
+    },
+    {
+    "key": "ssn-full",
+    "value": "Full Social Security Number"
+    },
+    {
+    "key": "none",
+    "value": "I do not have a valid ID"
+    }
     ]
-  },
-  {
+    },
+    {
     "uuid": "e87ca867-c5a5-4e42-98d5-d742edd03de3",
     "lang": "en",
     "nvrf_id": "changed_name",
@@ -347,8 +347,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "f6634a79-49af-47a4-8e86-d74ba5b892b9",
     "lang": "en",
     "nvrf_id": "mail_apt_lot_number",
@@ -360,8 +360,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "9a5baee7-357b-4e59-b4f2-fe2525c0fd6c",
     "lang": "en",
     "nvrf_id": "mail_city",
@@ -373,8 +373,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "b0f80289-6084-4723-8278-110fda210f0d",
     "lang": "en",
     "nvrf_id": "mail_state",
@@ -386,8 +386,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "db9b1f7a-565b-4aad-8d7c-56a553c18326",
     "lang": "en",
     "nvrf_id": "mail_address",
@@ -399,8 +399,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "c4f9c0cb-2a25-4f1d-a93a-b06a19656cfe",
     "lang": "en",
     "nvrf_id": "mail_zip_code",
@@ -412,8 +412,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "c3011c62-d174-420c-817a-bffbcd45687a",
     "lang": "en",
     "nvrf_id": "moved",
@@ -425,8 +425,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "f282e541-7ca8-4c22-8d87-d4cff56e22e5",
     "lang": "en",
     "nvrf_id": "first_name_2",
@@ -438,8 +438,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "42de34cc-ebf3-4d8e-8873-2571063b62c0",
     "lang": "en",
     "nvrf_id": "last_name_2",
@@ -451,8 +451,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "a4919026-91ac-4e05-a75f-e2df479abd76",
     "lang": "en",
     "nvrf_id": "middle_names_2",
@@ -464,8 +464,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "09cb2989-d302-4a01-bb3a-33173adcffb2",
     "lang": "en",
     "nvrf_id": "suffix_2",
@@ -477,29 +477,29 @@
     "section_description": "",
     "section_alert": "",
     "options": [
-      {
-        "key": "Jr.",
-        "value": "Jr."
-      },
-      {
-        "key": "Sr.",
-        "value": "Sr."
-      },
-      {
-        "key": "II",
-        "value": "II"
-      },
-      {
-        "key": "III",
-        "value": "III"
-      },
-      {
-        "key": "IV",
-        "value": "IV"
-      }
+    {
+    "key": "Jr.",
+    "value": "Jr."
+    },
+    {
+    "key": "Sr.",
+    "value": "Sr."
+    },
+    {
+    "key": "II",
+    "value": "II"
+    },
+    {
+    "key": "III",
+    "value": "III"
+    },
+    {
+    "key": "IV",
+    "value": "IV"
+    }
     ]
-  },
-  {
+    },
+    {
     "uuid": "34d2669a-d30b-4001-b897-280fe71b3cb0",
     "lang": "en",
     "nvrf_id": "title_2",
@@ -511,25 +511,25 @@
     "section_description": "",
     "section_alert": "",
     "options": [
-      {
-        "key": "Mr.",
-        "value": "Mr"
-      },
-      {
-        "key": "Miss",
-        "value": "Miss"
-      },
-      {
-        "key": "Ms.",
-        "value": "Ms"
-      },
-      {
-        "key": "Mrs.",
-        "value": "Mrs"
-      }
+    {
+    "key": "Mr.",
+    "value": "Mr"
+    },
+    {
+    "key": "Miss",
+    "value": "Miss"
+    },
+    {
+    "key": "Ms.",
+    "value": "Ms"
+    },
+    {
+    "key": "Mrs.",
+    "value": "Mrs"
+    }
     ]
-  },
-  {
+    },
+    {
     "uuid": "35c2b98d-477c-45f3-9f93-f720406080f1",
     "lang": "en",
     "nvrf_id": "no_street_address",
@@ -541,8 +541,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "2d61b54a-e568-410f-825a-0ca82dfd3f63",
     "lang": "en",
     "nvrf_id": "telephone_number",
@@ -550,12 +550,12 @@
     "label": "Phone number",
     "help_text": "(123) 456-7890",
     "error_msg": "Phone number must be 10 digits.",
-    "instructions": "\u003Cp\u003EYou do not have to provide your telephone number. This is used if election officials have questions about your form.\u003C\/p\u003E",
+    "instructions": "<p>You do not have to provide your telephone number. This is used if election officials have questions about your form.</p>",
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "c8e2ff17-fb1f-4971-a664-ffbb557b305a",
     "lang": "en",
     "nvrf_id": "prev_apt_lot_number",
@@ -567,8 +567,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "44bf0a5c-adba-4b47-bc99-cc46cede5e80",
     "lang": "en",
     "nvrf_id": "prev_city",
@@ -580,8 +580,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "5a8a4b6d-c0f1-42f2-b991-8ea49a32e997",
     "lang": "en",
     "nvrf_id": "prev_state",
@@ -593,8 +593,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "c037a3ea-86b7-4661-ad28-c7228f1e682b",
     "lang": "en",
     "nvrf_id": "prev_address",
@@ -606,8 +606,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "49a90983-1925-438f-8271-88f39bf19bf1",
     "lang": "en",
     "nvrf_id": "prev_zip_code",
@@ -619,8 +619,8 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "2bfff6c6-6782-4b14-ac45-642efd278f6a",
     "lang": "en",
     "nvrf_id": "race_ethnic_group",
@@ -628,41 +628,41 @@
     "label": "Race or ethnic group",
     "help_text": false,
     "error_msg": "Race or ethnic group must be filled out.",
-    "instructions": "\u003Cp\u003ESelect the choice that best describes you from the list.\u003C\/p\u003E",
+    "instructions": "<p>Select the choice that best describes you from the list.</p>",
     "section_description": "",
     "section_alert": "",
     "options": [
-      {
-        "key": "American Indian or Alaskan Native",
-        "value": "American Indian or Alaskan Native"
-      },
-      {
-        "key": "Asian or Pacific Islander",
-        "value": "Asian or Pacific Islander"
-      },
-      {
-        "key": "Black, not of Hispanic Origin",
-        "value": "Black, not of Hispanic Origin"
-      },
-      {
-        "key": "Hispanic",
-        "value": "Hispanic"
-      },
-      {
-        "key": "Multi-racial",
-        "value": "Multi-racial"
-      },
-      {
-        "key": "White, not of Hispanic Origin",
-        "value": "White, not of Hispanic Origin"
-      },
-      {
-        "key": "Other",
-        "value": "Other"
-      }
+    {
+    "key": "American Indian or Alaskan Native",
+    "value": "American Indian or Alaskan Native"
+    },
+    {
+    "key": "Asian or Pacific Islander",
+    "value": "Asian or Pacific Islander"
+    },
+    {
+    "key": "Black, not of Hispanic Origin",
+    "value": "Black, not of Hispanic Origin"
+    },
+    {
+    "key": "Hispanic",
+    "value": "Hispanic"
+    },
+    {
+    "key": "Multi-racial",
+    "value": "Multi-racial"
+    },
+    {
+    "key": "White, not of Hispanic Origin",
+    "value": "White, not of Hispanic Origin"
+    },
+    {
+    "key": "Other",
+    "value": "Other"
+    }
     ]
-  },
-  {
+    },
+    {
     "uuid": "8dda085c-edf3-4678-b30a-0a457699be46",
     "lang": "en",
     "nvrf_id": "null",
@@ -671,11 +671,11 @@
     "help_text": false,
     "error_msg": false,
     "instructions": "",
-    "section_description": "\u003Cp\u003EUsing the name on your driver\u2019s license or other non-driver ID is recommended.\u003C\/p\u003E",
-    "section_alert": "\u003Cp\u003EEnter your full legal name. Be sure to include your first, middle, and last name. Do not use nicknames or initials.\u003C\/p\u003E",
+    "section_description": "<p>Using the name on your driver’s license or other non-driver ID is recommended.</p>",
+    "section_alert": "<p>Enter your full legal name. Be sure to include your first, middle, and last name. Do not use nicknames or initials.</p>",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "63552bb6-6afb-46e1-8148-860242917a22",
     "lang": "en",
     "nvrf_id": "null",
@@ -685,10 +685,10 @@
     "error_msg": false,
     "instructions": "",
     "section_description": "",
-    "section_alert": "\u003Cp\u003EEnter your home address (legal address). Do not put your mailing address here if it\u2019s different from your home address. Do not use a post office box or rural route without a box number.\u003C\/p\u003E",
+    "section_alert": "<p>Enter your home address (legal address). Do not put your mailing address here if it’s different from your home address. Do not use a post office box or rural route without a box number.</p>",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "1a856408-6fb2-4b09-b05a-8d8ee9eb9bb5",
     "lang": "en",
     "nvrf_id": "null",
@@ -697,11 +697,24 @@
     "help_text": false,
     "error_msg": false,
     "instructions": "",
-    "section_description": "\u003Cp\u003EEnter the address where you receive mail so voter registration materials can be sent to you. You can use a post office box number.\u003C\/p\u003E",
-    "section_alert": "\u003Cp\u003EIf you live in a rural area but do not have a street address, or if you have no address, you must enter an address where you can be reached by mail. You will have the opportunity to show where you live on a map when you print out your form.\u003C\/p\u003E",
+    "section_description": "<p>Enter the address where you receive mail so voter registration materials can be sent to you. You can use a post office box number.</p>",
+    "section_alert": "<p>If you live in a rural area but do not have a street address, or if you have no address, you must enter an address where you can be reached by mail. You will have the opportunity to show where you live on a map when you print out your form.</p>",
     "options": []
-  },
-  {
+    },
+    {
+    "uuid": "6dd20906-654e-427e-bb82-1e62aee9ed72",
+    "lang": "en",
+    "nvrf_id": "null",
+    "name": "Section: Moved and No Street Address",
+    "label": "Check one or both boxes if they apply to you.",
+    "help_text": false,
+    "error_msg": false,
+    "instructions": "",
+    "section_description": "",
+    "section_alert": "",
+    "options": []
+    },
+    {
     "uuid": "af4e6259-5b07-4955-9d28-254504ec9df8",
     "lang": "en",
     "nvrf_id": "null",
@@ -713,8 +726,21 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
+    "uuid": "3724c7cd-5ec7-4e3e-85cd-db0cab63e99b",
+    "lang": "en",
+    "nvrf_id": "null",
+    "name": "Section: No Street Address",
+    "label": "Check this box if it applies to you.",
+    "help_text": false,
+    "error_msg": false,
+    "instructions": "",
+    "section_description": "",
+    "section_alert": "",
+    "options": []
+    },
+    {
     "uuid": "023fda0f-e8bd-4654-ab5c-46f44a0b7bd6",
     "lang": "en",
     "nvrf_id": "null",
@@ -723,11 +749,11 @@
     "help_text": false,
     "error_msg": false,
     "instructions": "",
-    "section_description": "\u003Cp\u003EIf you were registered before but this is the first time you are registering from this address, please tell us the address where you were registered before. Please give us as much of the address as you can remember.\u003C\/p\u003E",
+    "section_description": "<p>If you were registered before but this is the first time you are registering from this address, please tell us the address where you were registered before. Please give us as much of the address as you can remember.</p>",
     "section_alert": "",
     "options": []
-  },
-  {
+    },
+    {
     "uuid": "7231330d-523b-4e22-b282-b9f98ee20ef2",
     "lang": "en",
     "nvrf_id": "state",
@@ -739,5 +765,5 @@
     "section_description": "",
     "section_alert": "",
     "options": []
-  }
+    }
 ]

--- a/src/Views/FormPages/Addresses.jsx
+++ b/src/Views/FormPages/Addresses.jsx
@@ -41,12 +41,15 @@ function Addresses(props){
     const mailStateField = fields.find(item => item.uuid === "b0f80289-6084-4723-8278-110fda210f0d");
     const mailZipcodeField = fields.find(item => item.uuid === "c4f9c0cb-2a25-4f1d-a93a-b06a19656cfe");
 
+    const noAddressSection = fields.find(item => item.uuid === "3724c7cd-5ec7-4e3e-85cd-db0cab63e99b");
+    const movedAndNoAddressSection = fields.find(item => item.uuid === "6dd20906-654e-427e-bb82-1e62aee9ed72");
+
     //Field requirements by state data
     const addressFieldsState = (nvrfStateFields.find(item => item.uuid === streetAddressField.uuid));
 
-    // Instructions for optional checkboxes (prev address, no address)
-    const addressCheckBoxInstructions = sanitizeDOM(noAddressField.instructions);
-    const addressCheckBoxesInstructions = sanitizeDOM(prevAddressField.instructions);
+    // Instructions for optional checkboxes
+    const noAddressCheckboxInstructions = sanitizeDOM(noAddressSection.label);
+    const movedAndNoAddressCheckboxInstructions = sanitizeDOM(movedAndNoAddressSection.label);
 
     return (
         <>
@@ -55,11 +58,11 @@ function Addresses(props){
         {addressFieldsState && (
             <>
             {!changeRegistrationVisible && (
-                <span className='usa-hint' id='addresses-checkbox-hint'>{addressCheckBoxInstructions}</span>
+                <span className='usa-hint' id='addresses-checkbox-hint'>{noAddressCheckboxInstructions}</span>
             )}
             { changeRegistrationVisible && (
                 <>
-                <span className='usa-hint' id='addresses-checkbox-hint'>{addressCheckBoxesInstructions}</span>
+                <span className='usa-hint' id='addresses-checkbox-hint'>{movedAndNoAddressCheckboxInstructions}</span>
                 <Checkbox id="prev-address" name="prev-address" data-test="checkBox" checked={props.hasPreviousAddress} onChange={props.onChangePreviousAddressCheckbox} label={prevAddressField.label} />
                 </>
             )}


### PR DESCRIPTION
Added instruction text for address checkboxes.
When the user is updating their registration, the checkboxes and instructions appear like this:
![image](https://github.com/user-attachments/assets/f8cf5e19-0c94-4c77-b8e3-cc683d07cb89)

When the user is creating a new registration, the checkbox and instructions appear like this:
![image](https://github.com/user-attachments/assets/6d694503-153e-49e3-be36-0be686bf5d55)

To test, begin the digital form filler for updating a registration and continue to the 'Address and location' page. Ensure that the text appears as it does in the above screenshot, and that both checkboxes function correctly (the page should respond when either/both checkboxes are checked).
Then, go back and begin a new registration, continue to the 'Address and location' page, and ensure that the text matches the second screenshot above.