### PR TITLE
VOTE-2323: Field Container for driver's license

### DIFF
--- a/src/Components/Fields/DriversLicenseNumber.jsx
+++ b/src/Components/Fields/DriversLicenseNumber.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+import FieldContainer from 'Components/FieldContainer';
+import {getField} from "Utils/fieldParser";
+
+function DriversLicenseNumber(props){
+    const uuid = "acd7f272-7a37-43f0-b51a-c78daf31e5fd";
+    const field = getField(props.fieldContent, uuid);
+    const stateField = getField(props.stateData.nvrf_fields, field.uuid);
+
+    return (
+        <FieldContainer
+            fieldType={'text'} inputData={{
+            id: field.nvrf_id,
+            dataTest: 'driverId',
+            label: field.label,
+            required: stateField.required,
+            error_msg: field.error_msg,
+            help_text: field.help_text,
+        }} saveFieldData={props.saveFieldData} fieldData={props.fieldData}/>
+    )
+}
+
+export default DriversLicenseNumber;

--- a/src/Views/FormPages/Identification.jsx
+++ b/src/Views/FormPages/Identification.jsx
@@ -2,6 +2,7 @@ import { Label, TextInput, Checkbox, Select } from '@trussworks/react-uswds';
 import React from "react";
 import { restrictType, checkForErrors, toggleError } from 'Utils/ValidateField';
 import { sanitizeDOM } from 'Utils/JsonHelper';
+import DriversLicenseNumber from 'Components/Fields/DriversLicenseNumber';
 
 function Identification(props){
     const headings = props.headings;
@@ -83,27 +84,7 @@ function Identification(props){
                     <>
                         {((props.idType === 'driver-id-num') || (stateData.abbrev === "mo")) &&
                         <>
-                            <Label className="text-bold" htmlFor="id-driver">
-                                {driverLicenseField.label}{(driverIDFieldReq) && <span className='required-text'>*</span>}
-                            </Label>
-                            <TextInput
-                                data-test="driverId"
-                                id="id-driver"
-                                className="radius-md"
-                                name="id-driver"
-                                aria-describedby="id-driver_error"
-                                type="text"
-                                autoComplete="off"
-                                required={parseInt(driverIDFieldReq.required)}
-                                value={props.fieldData.id_number}
-                                onChange={props.saveFieldData('id_number')}
-                                onBlur={(e) => toggleError(e, checkForErrors(e, 'check value exists'))}
-                                onInvalid={(e) => e.target.setCustomValidity(' ')}
-                                onInput={(e) => e.target.setCustomValidity('')}
-                            />
-                            <span id="id-driver_error" role="alert" className='error-text' data-test="errorText">
-                                {driverLicenseField.error_msg}
-                            </span>
+                            <DriversLicenseNumber {...props} />
                         </>
                         }
                         {(props.idType === 'state-id-num') &&


### PR DESCRIPTION
Added a field container for driver's license number. The field maintains intended functionality, and the number entered by the user appears in the filled PDF.

To test, complete the online registration form, and select 'State driver's license number' on the Identification page. Enter a number into the text field, and check that the number entered appears in the final PDF. If the field is left blank, an error message should display:
![image](https://github.com/user-attachments/assets/cf2f3a59-323a-40ba-beb2-9ba6550f1104)
