### PR TITLE
VOTE-2414: Hover state styling for previous steps

### DIFF
--- a/public/theme/assets/styles/nvrf.css
+++ b/public/theme/assets/styles/nvrf.css
@@ -58,6 +58,34 @@
     }
 }
 
+/* Color for future segments */
+.nvrf-app-container .usa-step-indicator__segment-label {
+    /* color: #b50909; */
+}
+
+.nvrf-app-container .usa-step-indicator__segment::after {
+    /* background-color: #b50909; */
+}
+
+/* Color for current segment */
+.nvrf-app-container .usa-step-indicator__segment--current::after {
+    /* background-color: #09b57f; */
+}
+
+.nvrf-app-container .usa-step-indicator__segment--current .usa-step-indicator__segment-label {
+    /* color: #09b57f; */
+}
+
+/* Color for completed segments */
+.nvrf-app-container .usa-step-indicator__segment--complete::after {
+    /* background-color: #ff19c2; */
+}
+
+.nvrf-app-container .usa-step-indicator__segment--complete .usa-step-indicator__segment-label {
+    /* color: #ff19c2; */
+}
+
+
 .nvrf-app-container .usa-alert__text {
     > *:first-child {
         margin-top: 0;

--- a/public/theme/assets/styles/nvrf.css
+++ b/public/theme/assets/styles/nvrf.css
@@ -48,43 +48,26 @@
 
 .nvrf-app-container .usa-step-indicator__segment {
     cursor: default;
+    padding-bottom: .5rem;
 }
 
 .nvrf-app-container .usa-step-indicator__segment--complete {
     cursor: pointer;
+    background-color: transparent;
+    color: transparent;
+    transition: color .5s, background-color .5s;
     &:hover,
     &:focus {
         text-decoration: underline;
+        color: #005ea2;
+        background-color: #e7eff3;
+        transition: text-decoration .5s, color .5s, background-color .5s;
+        .usa-step-indicator__segment-label {
+            color: #005ea2;
+            transition: color .5s;
+        }
     }
 }
-
-/* Color for future segments */
-.nvrf-app-container .usa-step-indicator__segment-label {
-    /* color: #b50909; */
-}
-
-.nvrf-app-container .usa-step-indicator__segment::after {
-    /* background-color: #b50909; */
-}
-
-/* Color for current segment */
-.nvrf-app-container .usa-step-indicator__segment--current::after {
-    /* background-color: #09b57f; */
-}
-
-.nvrf-app-container .usa-step-indicator__segment--current .usa-step-indicator__segment-label {
-    /* color: #09b57f; */
-}
-
-/* Color for completed segments */
-.nvrf-app-container .usa-step-indicator__segment--complete::after {
-    /* background-color: #ff19c2; */
-}
-
-.nvrf-app-container .usa-step-indicator__segment--complete .usa-step-indicator__segment-label {
-    /* color: #ff19c2; */
-}
-
 
 .nvrf-app-container .usa-alert__text {
     > *:first-child {

--- a/src/Components/ProgressBar.jsx
+++ b/src/Components/ProgressBar.jsx
@@ -30,27 +30,27 @@ function ProgressBar(props) {
             <div aria-live="polite" aria-atomic="true" className="usa-sr-only">{currentStepMessage}</div>
             <StepIndicator centered className="margin-top-4" headingLevel="h2">
                 <StepIndicatorStep label={props.content.step_label_1} status={stepProgress(1)}
-                tabIndex={stepProgress(1) === "complete" ? 0 : -1}
+                tabIndex={stepProgress(1) === "complete" ? 0 : null}
                 onKeyDown={(e) => {if (e.key === "Enter" && stepProgress(1) === "complete") {setStep(1)}}}
                 onClick={stepProgress(1) === "complete" ? handleGoBackSteps(props.step - 1) : null}/>
 
                 <StepIndicatorStep label={props.content.step_label_2} status={stepProgress(2)}
-                tabIndex={stepProgress(2) === "complete" ? 0 : -1}
+                tabIndex={stepProgress(2) === "complete" ? 0 : null}
                 onKeyDown={(e) => {if (e.key === "Enter" && stepProgress(2) === "complete") {setStep(2)}}}
                 onClick={stepProgress(2) === "complete" ? handleGoBackSteps(props.step - 2) : null}/>
 
                 <StepIndicatorStep label={props.content.step_label_3} status={stepProgress(3)}
-                tabIndex={stepProgress(3) === "complete" ? 0 : -1}
+                tabIndex={stepProgress(3) === "complete" ? 0 : null}
                 onKeyDown={(e) => {if (e.key === "Enter" && stepProgress(3) === "complete") {setStep(3)}}}
                 onClick={stepProgress(3) === "complete" ? handleGoBackSteps(props.step - 3) : null}/>
 
                 <StepIndicatorStep label={props.content.step_label_4} status={stepProgress(4)}
-                tabIndex={stepProgress(4) === "complete" ? 0 : -1}
+                tabIndex={stepProgress(4) === "complete" ? 0 : null}
                 onKeyDown={(e) => {if (e.key === "Enter" && stepProgress(4) === "complete") {setStep(4)}}}
                 onClick={stepProgress(4) === "complete" ? handleGoBackSteps(props.step - 4) : null}/>
 
                 <StepIndicatorStep label={props.content.step_label_5} status={stepProgress(5)}
-                tabIndex={stepProgress(5) === "complete" ? 0 : -1}
+                tabIndex={stepProgress(5) === "complete" ? 0 : null}
                 onKeyDown={(e) => {if (e.key === "Enter" && stepProgress(5) === "complete") {setStep(5)}}}
                 onClick={stepProgress(5) === "complete" ? handleGoBackSteps(props.step - 5) : null}/>
 


### PR DESCRIPTION
Jira ticket: https://cm-jira.usa.gov/browse/VOTE-2414

Added hover/focus state styling for previous steps in the step indicator to show that they are clickable/interactable. When hovering or focusing on a previous step, the text should be underlined and shift to a blue color, while the background of that step shifts to a light blue color. See below example, where the mouse is hovering over the 'Address and location' step.

![image](https://github.com/user-attachments/assets/701abfcf-0ed6-40a9-9d69-e6c0f0c4fe86)

To test, open the form filler and check that no hover/focus styles are present on the current or future step segments. Then, complete at least one step of the form, and then check the hover/focus styles on the completed step segment. The styling shown above should appear when the segment is under the mouse, or when the user uses 'tab' to focus on the completed segment (the blue outline to show the current focused element should also be present when tab focusing is being used). Also click the completed segment to ensure that the functionality of jumping back to the previous step is still working.
