### PR TITLE
VOTE-1019: Add Field grouping for screen readers

### DIFF
--- a/src/Views/FormPages/Addresses.jsx
+++ b/src/Views/FormPages/Addresses.jsx
@@ -67,7 +67,7 @@ function Addresses(props){
                 {/******** Current Address Block *********/}
                 { !props.hasNoAddress && (<>
                     {homeAddressSectionField.section_alert && (
-                    <div id="no-address_alert" className="usa-alert usa-alert--info" role="region" aria-live="polite">
+                    <div id="no-address_alert" className="usa-alert usa-alert--info" role="region" aria-live="polite" aria-label="informative alert">
                         <div className="usa-alert__body">
                             <div className="usa-alert__text" dangerouslySetInnerHTML= {{__html: homeAddressSectionField.section_alert}}/>
                         </div>

--- a/src/Views/FormPages/Addresses.jsx
+++ b/src/Views/FormPages/Addresses.jsx
@@ -1,4 +1,4 @@
-import { Label, TextInput, Checkbox, Grid } from '@trussworks/react-uswds';
+import { Label, TextInput, Checkbox, Grid, Fieldset } from '@trussworks/react-uswds';
 import StateSelector from 'Components/StateSelector';
 import CurrentAddressState from 'Components/Fields/CurrentAddressState';
 import CurrentStreetAddress from 'Components/Fields/CurrentStreetAddress';
@@ -73,36 +73,39 @@ function Addresses(props){
                         </div>
                     </div> )}
 
-                    <h3 className='margin-top-5'>{homeAddressSectionField.label}</h3>
-                        {homeAddressSectionField.instructions && (
-                            <div dangerouslySetInnerHTML={{__html: homeAddressSectionField.instructions}}/>
-                        )}
+                    <Fieldset legend={<h3 className='margin-top-5'>{homeAddressSectionField.label}</h3>}>
+                        <div role="group" aria-label="Current Address">
+                            {homeAddressSectionField.instructions && (
+                                <div dangerouslySetInnerHTML={{__html: homeAddressSectionField.instructions}}/>
+                            )}
 
-                    <Grid row gap className={'flex-align-end'}>
-                        <Grid tablet={{col: 12}}>
-                            <CurrentStreetAddress {...props} />
-                        </Grid>
-                    </Grid>
+                            <Grid row gap className={'flex-align-end'}>
+                                <Grid tablet={{col: 12}}>
+                                    <CurrentStreetAddress {...props} />
+                                </Grid>
+                            </Grid>
 
-                    <Grid row gap className={'flex-align-end'}>
-                        <Grid tablet={{ col: 5}}>
-                            <CurrentApartmentNumber {...props} />
-                        </Grid>
-                    </Grid>
+                            <Grid row gap className={'flex-align-end'}>
+                                <Grid tablet={{ col: 5}}>
+                                    <CurrentApartmentNumber {...props} />
+                                </Grid>
+                            </Grid>
 
-                    <Grid row gap className={'flex-align-end'}>
-                        <Grid tablet={{ col: 4 }}>
-                            <CurrentCity {...props} />
-                        </Grid>
+                            <Grid row gap className={'flex-align-end'}>
+                                <Grid tablet={{ col: 4 }}>
+                                    <CurrentCity {...props} />
+                                </Grid>
 
-                        <Grid tablet={{ col: 4 }}>
-                            <CurrentAddressState {...props} />
-                        </Grid>
+                                <Grid tablet={{ col: 4 }}>
+                                    <CurrentAddressState {...props} />
+                                </Grid>
 
-                        <Grid tablet={{ col: 3 }}>
-                            <CurrentZipCode {...props} />
-                        </Grid>
-                    </Grid>
+                                <Grid tablet={{ col: 3 }}>
+                                    <CurrentZipCode {...props} />
+                                </Grid>
+                            </Grid>
+                        </div>
+                    </Fieldset>
                     <Checkbox data-test="checkBox" className="margin-top-3" id="alt-mail-addr" name="alt-mail-addr" checked={props.hasMailAddress} onChange={props.onChangeMailAddressCheckbox} label={differentMailAddressField.label} />
                 </>
                 )}

--- a/src/Views/FormPages/Confirmation.jsx
+++ b/src/Views/FormPages/Confirmation.jsx
@@ -177,7 +177,7 @@ function Confirmation(props) {
 
             {confirmInstructions && (
                 <div id="acknowledge-check-alert" className="usa-alert usa-alert--info margin-top-6" role="region"
-                     aria-live="polite">
+                     aria-live="polite" aria-label="informative alert">
                     <div className="usa-alert__body">
                         <div className="usa-alert__text" dangerouslySetInnerHTML={{__html: confirmInstructions}}/>
                     </div>

--- a/src/Views/FormPages/Identification.jsx
+++ b/src/Views/FormPages/Identification.jsx
@@ -36,7 +36,7 @@ function Identification(props){
         <h2>{headings.step_label_3}</h2>
 
             {idStateInstructions && (
-                <div id="id_alert" className="usa-alert usa-alert--info" role="region" aria-live="polite">
+                <div id="id_alert" className="usa-alert usa-alert--info" role="region" aria-live="polite" aria-label="informative alert">
                     <div className="usa-alert__body">
                         <div className="usa-alert__text" dangerouslySetInnerHTML={{__html: idStateInstructions}}/>
                     </div>

--- a/src/Views/FormPages/PersonalInfo.jsx
+++ b/src/Views/FormPages/PersonalInfo.jsx
@@ -108,7 +108,7 @@ function PersonalInfo(props){
             </div>
         </div>
 
-        <Fieldset legend={<h3 className={'margin-top-5 margin-bottom-0'}>{nameSectionField.label}</h3>} className="fieldset">
+        <Fieldset legend={<h3 className={'margin-top-5 margin-bottom-0'}>{nameSectionField.label}</h3>}>
         <div dangerouslySetInnerHTML= {{__html: nameSectionDesc}}/>
         <div role="group" aria-label="Legal Name">
         {nameFieldState && (

--- a/src/Views/FormPages/PersonalInfo.jsx
+++ b/src/Views/FormPages/PersonalInfo.jsx
@@ -102,13 +102,13 @@ function PersonalInfo(props){
             <Checkbox id="prev-name-change" aria-describedby="prev-name-change_alert" name="prev-name-change" data-test="checkBox" checked={props.previousName} onChange={props.onChangePreviousName} label={stringContent.nameChange} />
         )}
 
-        <div id="prev-name-change_alert" className="usa-alert usa-alert--info" role="region" aria-live="polite">
+        <div id="prev-name-change_alert" className="usa-alert usa-alert--info" role="region" aria-live="polite" aria-label="informative alert">
             <div className="usa-alert__body">
                 <div className="usa-alert__text" dangerouslySetInnerHTML={{__html: nameSectionAlert}}/>
             </div>
         </div>
 
-        <h3 className={'margin-top-5'}>{nameSectionField.label}</h3>
+        <Fieldset legend={<h3 className={'margin-top-5 margin-bottom-0'}>{nameSectionField.label}</h3>} className="fieldset">
         <div dangerouslySetInnerHTML= {{__html: nameSectionDesc}}/>
 
         {nameFieldState && (
@@ -138,6 +138,7 @@ function PersonalInfo(props){
                 </Grid>
             </>
         )}
+        </Fieldset>
 
         <Grid row gap className={'flex-align-end'}>
             <Grid tablet={{ col: 5 }}>

--- a/src/Views/FormPages/PersonalInfo.jsx
+++ b/src/Views/FormPages/PersonalInfo.jsx
@@ -110,7 +110,7 @@ function PersonalInfo(props){
 
         <Fieldset legend={<h3 className={'margin-top-5 margin-bottom-0'}>{nameSectionField.label}</h3>} className="fieldset">
         <div dangerouslySetInnerHTML= {{__html: nameSectionDesc}}/>
-
+        <div role="group" aria-label="Legal Name">
         {nameFieldState && (
             <>
                 <Grid row gap className={'flex-align-end'}>
@@ -138,6 +138,7 @@ function PersonalInfo(props){
                 </Grid>
             </>
         )}
+        </div>
         </Fieldset>
 
         <Grid row gap className={'flex-align-end'}>

--- a/src/Views/FormPages/PoliticalParty.jsx
+++ b/src/Views/FormPages/PoliticalParty.jsx
@@ -23,7 +23,7 @@ function PoliticalParty(props){
         <h2>{headings.step_label_4}</h2>
 
         {(partyStateInstructions || partyGeneralInstructions) && (
-        <div className="usa-alert usa-alert--info" role="region" aria-live="polite">
+        <div className="usa-alert usa-alert--info" role="region" aria-live="polite" aria-label="informative alert">
             <div className="usa-alert__body">
                 <div className="usa-alert__text" dangerouslySetInnerHTML={{__html: partyStateInstructions}}/>
             </div>


### PR DESCRIPTION
This ticket aims to accomplish two things:
1. Add an `aria-label` to the blue informative alert so that a screen reader will read its text contents (before, the screen reader would skip over this element completely)
2. Add field groupings (eg. to all of the name-related fields on the Personal information page) for screen readers

To test, open the NVRF form filler and run WAVE. The blue informative alert should have an aria-label, like below:
![image](https://github.com/user-attachments/assets/3b0e4e20-f34b-4477-801d-54e9b79fbf38)

The associated fields should be contained within a <div> with role "group" and an appropriate aria-label, like below:
![image](https://github.com/user-attachments/assets/71ada490-e372-42e8-ac3b-d79a48d52f40)

Repeat this for the Personal Information and Address pages (which have both informative alerts and Fieldsets). Also check the informative alerts on the Identification and Political party pages.
