### PR TITLE
VOTE-2578: Migrate checkDateValues to DateFields

### DIFF
--- a/src/Components/FieldComponents/DateFields.jsx
+++ b/src/Components/FieldComponents/DateFields.jsx
@@ -1,7 +1,64 @@
 import React from "react";
 import { restrictType, checkForErrors, jumpTo, toggleError } from 'Utils/ValidateField';
 
-function DateFields({ inputData, saveFieldData, dateFormat, checkDateValues, fieldData }) {
+function DateFields({ inputData, saveFieldData, dateFormat, fieldData }) {
+
+    const checkDateValues = (e, type) => {
+        let month = fieldData.date_of_birth_month;
+        let day = fieldData.date_of_birth_day;
+        let year = fieldData.date_of_birth_year;
+        let yearStart = year.slice(0, 2);
+
+        let currentDate = new Date();
+        let currentMonth = currentDate.getMonth();
+        let currentDay = currentDate.getDate();
+        let currentYear = currentDate.getFullYear();
+        let age = currentYear - year - (currentMonth <= month && currentDay < day);
+        
+        if (type === "all") {
+          let dobValues = [
+            month.length === 2,
+            day.length === 2,
+            year.length === 4,
+
+            month <= 12,
+            month >= 1,
+            day <= 31,
+            day >= 1,
+            yearStart <= 20,
+            yearStart >= 19,
+            age <= 120,
+            age >= 16
+          ];
+
+          if (dobValues.includes(false)) {
+            e.target.setCustomValidity(' ');
+            return true
+          } else {
+            return false
+          }
+
+        } else if (type === "month") {
+          if (month > 12 || month < 1) {
+            return true
+          } else {
+            return false
+          }
+        } else if (type === "day") {
+          if (day > 31 || day < 1) {
+            return true
+          } else {
+            return false
+          }
+        } else if (type === "year") {
+          if (age > 110 || age < 17) {
+            return true
+          } else {
+            return false
+          }
+        }
+    };
+
     return (
         <div
         id={inputData.id}

--- a/src/Components/Fields/CurrentDateOfBirth.jsx
+++ b/src/Components/Fields/CurrentDateOfBirth.jsx
@@ -17,7 +17,7 @@ function CurrentDateOfBirth(props){
             stringContent: props.stringContent,
             error_msg: field.error_msg,
             help_text: field.help_text,
-        }} saveFieldData={props.saveFieldData} fieldData={props.fieldData} checkDateValues={props.checkDateValues} dateFormat={props.dateFormat} />
+        }} saveFieldData={props.saveFieldData} fieldData={props.fieldData} dateFormat={props.dateFormat} />
     )
 }
 

--- a/src/Components/FieldsetContainer.jsx
+++ b/src/Components/FieldsetContainer.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Fieldset } from '@trussworks/react-uswds';
 import DateFields from 'Components/FieldComponents/DateFields';
 
-function FieldsetContainer({ fieldType, inputData, saveFieldData, dateFormat, checkDateValues, fieldData }) {
+function FieldsetContainer({ fieldType, inputData, saveFieldData, dateFormat, fieldData }) {
     function renderField(fieldType) {
         switch (fieldType) {
             case 'date':
@@ -10,7 +10,6 @@ function FieldsetContainer({ fieldType, inputData, saveFieldData, dateFormat, ch
                     inputData={inputData}
                     saveFieldData={saveFieldData}
                     dateFormat={dateFormat}
-                    checkDateValues={checkDateValues}
                     fieldData={fieldData} />;
         }
     };

--- a/src/Views/FormPages/PersonalInfo.jsx
+++ b/src/Views/FormPages/PersonalInfo.jsx
@@ -37,63 +37,6 @@ function PersonalInfo(props){
     const telephoneFieldState = (nvrfStateFields.find(item => item.uuid === phoneNumberField.uuid));
     const raceFieldState = (nvrfStateFields.find(item => item.uuid === raceField.uuid));
 
-    const checkDateValues = (e, type) => {
-        let month = props.fieldData.date_of_birth_month;
-        let day = props.fieldData.date_of_birth_day;
-        let year = props.fieldData.date_of_birth_year;
-        let yearStart = year.slice(0, 2);
-
-        let currentDate = new Date();
-        let currentMonth = currentDate.getMonth();
-        let currentDay = currentDate.getDate();
-        let currentYear = currentDate.getFullYear();
-        let age = currentYear - year - (currentMonth <= month && currentDay < day);
-        
-        if (type === "all") {
-          let dobValues = [
-            month.length === 2,
-            day.length === 2,
-            year.length === 4,
-
-            month <= 12,
-            month >= 1,
-            day <= 31,
-            day >= 1,
-            yearStart <= 20,
-            yearStart >= 19,
-            age <= 120,
-            age >= 16
-          ];
-
-          if (dobValues.includes(false)) {
-            e.target.setCustomValidity(' ');
-            return true
-          } else {
-            return false
-          }
-
-        } else if (type === "month") {
-          if (month > 12 || month < 1) {
-            return true
-          } else {
-            return false
-          }
-        } else if (type === "day") {
-          if (day > 31 || day < 1) {
-            return true
-          } else {
-            return false
-          }
-        } else if (type === "year") {
-          if (age > 110 || age < 17) {
-            return true
-          } else {
-            return false
-          }
-        }
-      };
-
-
     return (
         <>
         <h2>{headings.step_label_1}</h2>
@@ -141,7 +84,7 @@ function PersonalInfo(props){
 
         <Grid row gap className={'flex-align-end'}>
             <Grid tablet={{ col: 5 }}>
-                <CurrentDateOfBirth {...props} checkDateValues={checkDateValues} dateFormat={props.dateFormat} />
+                <CurrentDateOfBirth {...props} dateFormat={props.dateFormat} />
             </Grid>
 
             {telephoneFieldState && (


### PR DESCRIPTION
Moved the logic for the checkDateValues validation function from PersonalInfo.jsx to DateFields.jsx, and removed unneeded references to checkDateValues in CurrentDateOfBirth.jsx and FieldsetContainer.jsx.

To test, open the NVRF Personal Info page, and enter values into the date of birth field to ensure that the validation is still working correctly. See below for examples:
![image](https://github.com/user-attachments/assets/c06df083-9156-4584-af0e-539ccbb1cb63)
![image](https://github.com/user-attachments/assets/1c38672a-53ad-4159-96fa-dfdd17dd3add)