### PR TITLE
VOTE-2590: Add button to go back to state registration options

### DIFF
--- a/src/Views/Eligibility.jsx
+++ b/src/Views/Eligibility.jsx
@@ -27,6 +27,7 @@ function Eligibility(props) {
 
     return (
         <>
+            <BackButton stringContent={stringContent} type={'button'} onClick={props.handlePrev} text={navContent.back.state_reg_options}/>
             <div className={'usa-prose margin-top-5 maxw-tablet margin-x-auto'}>
             <h1>{content.title.replace("@state_name", stateContent.name)}</h1>
 


### PR DESCRIPTION
Added the button to go back to state registration options from the Eligibility Requirements page. The button appears here:
![image](https://github.com/user-attachments/assets/399f0264-fee5-4688-9a2c-bc16add61543)
It doesn't currently do anything, since it will navigate back to a vote.gov page (once NVRF and vote.gov are integrated). Clicking the button just reloads the current page.

To test, open the NVRF app and ensure the button appears in the correct place on the initial page. Click the button to ensure that it doesn't cause any issues.