### PR TITLE
VOTE-2543: Remove unused spans in FieldContainers

### DIFF
--- a/src/Components/FieldContainer.jsx
+++ b/src/Components/FieldContainer.jsx
@@ -26,13 +26,17 @@ function FieldContainer({ fieldType, inputData, saveFieldData, fieldData, string
         <Label className="text-bold" htmlFor={inputData.id}>
           {inputData.label}{(parseInt(inputData.required) === 1) && <span>*</span>}
         </Label>
-        <span className="usa-hint" id={`${inputData.id}` + '-hint'}>
-          {inputData.help_text}
-        </span>
+        {inputData.help_text && (
+          <span className="usa-hint" id={`${inputData.id}-hint`}>
+            {inputData.help_text}
+          </span>
+        )}
         {renderField(fieldType)}
-        <span id={`${inputData.id}` + '_error'} role="alert" className={'error-text'} data-test="errorText">
-          {inputData.error_msg}
-        </span>
+        {inputData.error_msg && (
+          <span id={`${inputData.id}` + '_error'} role="alert" className={'error-text'} data-test="errorText">
+            {inputData.error_msg}
+          </span>
+        )}
       </div>
     </>
   )


### PR DESCRIPTION
This fix removes empty spans for fields that do not have a hint and/or do not have an error message (the latter meaning that the field is not required). Previously, fields that did not have a hint would have an empty hint span, such as the First name field below:
![image](https://github.com/user-attachments/assets/8515e492-2487-4987-95f0-600117d69db3)
This fix removes the unused hint span:
![image](https://github.com/user-attachments/assets/d7da06d7-54f3-4105-abfc-2abe302df711)

Previously, fields that were not required (and did not have error text) would have an empty span for an error message, as seen with the Middle name field below:
![image](https://github.com/user-attachments/assets/1238b002-0e14-47b6-999a-603869c4d71c)
This fix removes the unused span:
![image](https://github.com/user-attachments/assets/d2545f3d-79a2-4c24-9d6a-b5474f1a2051)

To test, open the NVRF form and inspect each of the fields. Fields that do not have grey hint text should not have the hint span, and fields that are not required should not have the error message span.
