### PR TITLE
VOTE-2581: Implement container field for SSNFull

### DIFF
--- a/src/Components/Fields/SSNFull.jsx
+++ b/src/Components/Fields/SSNFull.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import FieldContainer from 'Components/FieldContainer';
+import {getField} from "Utils/fieldParser";
+
+function SSNFull(props){
+    const uuid = "fe8cf91e-f872-4ed7-848c-09c99a7d83c8";
+    const field = getField(props.fieldContent, uuid);
+    const stateField = getField(props.stateData.nvrf_fields, field.uuid);
+
+    return (
+        <FieldContainer
+            fieldType={'text'} inputData={{
+            id: 'ssn_number',
+            dataTest: 'ssn',
+            label: field.label,
+            required: stateField.required,
+            error_msg: field.error_msg,
+            help_text: field.help_text,
+            type: 'numeric',
+            inputMode: 'number',
+            maxLength: 9,
+            minLength: 9,
+            check: 'check value length',
+        }} saveFieldData={props.saveFieldData} fieldData={props.fieldData}/>
+    )
+}
+
+export default SSNFull;

--- a/src/Views/FormPages/Identification.jsx
+++ b/src/Views/FormPages/Identification.jsx
@@ -4,6 +4,7 @@ import { restrictType, checkForErrors, toggleError } from 'Utils/ValidateField';
 import { sanitizeDOM } from 'Utils/JsonHelper';
 import DriversLicenseNumber from 'Components/Fields/DriversLicenseNumber';
 import SSNPartial from 'Components/Fields/SSNPartial';
+import SSNFull from 'Components/Fields/SSNFull';
 import StateIDNum from 'Components/Fields/StateIDNum';
 
 function Identification(props){
@@ -103,32 +104,9 @@ function Identification(props){
 
             {props.idType === 'ssn-full' &&
                 <>
-                    <Label className="text-bold" htmlFor="ssn-full">
-                        {ssnFullField.label}{(ssnFullFieldReq) && <span className='required-text'>*</span>}
-                    </Label>
-                    <span className="usa-hint" id="ssn-hint">{ssnFullField.help_text}</span>
-                    <TextInput
-                        id="ssn-full"
-                        className="radius-md"
-                        name="ssn-full"
-                        aria-describedby="ssn-full_error"
-                        autoComplete="off"
-                        required={parseInt(ssnFullFieldReq.required)}
-                        type="text"
-                        inputMode="numeric"
-                        minLength={9}
-                        maxLength={9}
-                        value={props.fieldData.ssn_number}
-                        onChange={props.saveFieldData('ssn_number')}
-                        onKeyDown={(e) => restrictType(e, 'number')}
-                        onBlur={(e) => toggleError(e, checkForErrors(e, 'check value length'))}
-                        onInvalid={(e) => e.target.setCustomValidity(' ')}
-                        onInput={(e) => e.target.setCustomValidity('')}
-                    />
-                    <span id="ssn-full_error" role="alert" className='error-text' data-test="errorText">
-                        {ssnFullField.error_msg}
-                    </span>
+                    <SSNFull {...props} />
                 </>}
+                
             <div aria-live='polite'>
                 {props.idType === 'none' && <div dangerouslySetInnerHTML={{__html: noIdFieldInstructions}}/>}
             </div>


### PR DESCRIPTION
[VOTE-2581](https://cm-jira.usa.gov/browse/VOTE-2581)

Implements container field to the full social security number field.

Testing:

1. in index.html you will need to change `data-stateId="al"` to `data-stateId="va"` or another state that uses the full ssn field
2. Test the field making sure error handling works as expected and the data is saved on the confirm info page.
3. Edit the input and confirm the data is updated on confirm page