### PR TITLE
Vote-2703: Bug -> update select fields on personal info page

### DIFF
--- a/src/Components/Fields/CurrentSuffix.jsx
+++ b/src/Components/Fields/CurrentSuffix.jsx
@@ -5,7 +5,6 @@ import {getField} from "Utils/fieldParser";
 function CurrentSuffix(props){
   const uuid = "eeff4fa1-00f2-474b-a791-1a4146dab11a";
   const field = getField(props.fieldContent, uuid);
-  const stateField = getField(props.stateData.nvrf_fields, field.uuid);
 
   return (
     <FieldContainer
@@ -15,7 +14,7 @@ function CurrentSuffix(props){
       required: "0",
       label: field.label,
       options: field.options,
-      value: stateField.value,
+      value:props.fieldData['suffix'],
     }} saveFieldData={props.saveFieldData} fieldData={props.fieldData} stringContent={props.stringContent} />
   )
 }

--- a/src/Components/Fields/CurrentTitle.jsx
+++ b/src/Components/Fields/CurrentTitle.jsx
@@ -5,7 +5,6 @@ import {getField} from "Utils/fieldParser";
 function CurrentTitle(props){
     const uuid = "86a544cd-cfe9-456a-b634-176a37a38d6d";
     const field = getField(props.fieldContent, uuid);
-    const stateField = getField(props.stateData.nvrf_fields, field.uuid);
 
     return (
         <FieldContainer
@@ -17,6 +16,7 @@ function CurrentTitle(props){
             options: field.options,
             error_msg: field.error_msg,
             help_text: field.help_text,
+            value:props.fieldData['title'],
         }} saveFieldData={props.saveFieldData} fieldData={props.fieldData} stringContent={props.stringContent}/>
     )
 }

--- a/src/Components/Fields/PreviousSuffix.jsx
+++ b/src/Components/Fields/PreviousSuffix.jsx
@@ -5,7 +5,6 @@ import {getField} from "Utils/fieldParser";
 function PreviousSuffix(props){
   const uuid = "09cb2989-d302-4a01-bb3a-33173adcffb2";
   const field = getField(props.fieldContent, uuid);
-  const stateField = getField(props.stateData.nvrf_fields, field.uuid);
   return (
     <FieldContainer
       fieldType={'select'} inputData={{
@@ -14,7 +13,7 @@ function PreviousSuffix(props){
       required: "0",
       label: field.label,
       options: field.options,
-      value: stateField.value,
+      value:props.fieldData['prev_suffix'],
     }} saveFieldData={props.saveFieldData} fieldData={props.fieldData} stringContent={props.stringContent}/>
   )
 }

--- a/src/Components/Fields/PreviousTitle.jsx
+++ b/src/Components/Fields/PreviousTitle.jsx
@@ -16,6 +16,7 @@ function PreviousTitle(props){
             options: field.options,
             error_msg: field.error_msg,
             help_text: field.help_text,
+            value:props.fieldData['prev_title'],
         }} saveFieldData={props.saveFieldData} fieldData={props.fieldData} stringContent={props.stringContent}/>
     )
 }

--- a/src/Components/Fields/RaceEthnicity.jsx
+++ b/src/Components/Fields/RaceEthnicity.jsx
@@ -14,7 +14,7 @@ function RaceEthnicity(props){
       required: stateField.required,
       label: field.label,
       options: field.options,
-      value: stateField.value,
+      value:props.fieldData['race'],
       error_msg: field.error_msg,
     }} saveFieldData={props.saveFieldData} fieldData={props.fieldData} stringContent={props.stringContent}/>
   )


### PR DESCRIPTION
Ticket: [Vote-2703](https://cm-jira.usa.gov/browse/VOTE-2703)

Description:  Updated the value prop to help the data be saved once the user left the page and then returned 

Testing: 

1. Start up local and progress through form and select the update registration path
2. Fill out the options for current and prev suffix, current and prev title and race
3. Progress to the next page and return back to personal info... should verify that the same options are being displayed 
4. Complete form and use the edit button for personal info and verity that the same info is displaying
5. Verify that info is saved to the pdf form as well 