### PR TITLE
Vote-2278: Disable NVRF PDF Pipeline Job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,53 +2,54 @@ version: 2.1
 orbs:
   gh: circleci/github-cli@2.2.0
 jobs:
-  update-nvrf:
-    docker:
-      - image: cimg/base:stable
-    environment:
-      URL: https://www.eac.gov/sites/default/files/eac_assets/1/6/Federal_Voter_Registration_ENG.pdf
-      NVRF_FILE_NAME: Federal_Voter_Registration_ENG.pdf
-      NEW_BRANCH_NAME: upload-nvrf-pdf
-    steps:
-      #Install gh
-      - gh/install
-      - run:
-          name: Git Clone and Config
-          command: |
-            GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone -b "update-nvrf-pdf" "$CIRCLE_REPOSITORY_URL"
-            cd vote-gov-nvrf-app
-            git config user.email "circleci@df52e93b2563.(none)"
-            git config user.name "Pipeline Commit"
-      - run:
-          name: Fetch NVRF from eac.gov
-          command: |
-            curl -o Federal_Voter_Registration_ENG.pdf $URL
-      #Save pdf as an artifact
-      - store_artifacts:
-          path: Federal_Voter_Registration_ENG.pdf
-          destination: /pdf-files
-      # Create a variable to store the PDF artifact
-      - run:
-          name: Replace current NVRF
-          command: |
-            cd vote-gov-nvrf-app
-            artifacts=$(curl -X GET "https://circleci.com/api/v2/project/github/usagov/vote-gov-nvrf-app/$CIRCLE_BUILD_NUM/artifacts" \
-            -H "Accept: application/json" \
-            -u "$NVRF_PDF_WRITE:")
-            echo "read -r -d '' STORED_ARTIFACTS \<< 'EOF_ARTIFACTS'" >> $BASH_ENV
-            echo "$artifacts" >> $BASH_ENV
-            echo "EOF_ARTIFACTS" >> $BASH_ENV
-            cd public/files
-            rm $NVRF_FILE_NAME
-            echo $STORED_ARTIFACTS > $NVRF_FILE_NAME
-      - run:
-          name: Create Pull Request
-          shell: /bin/bash
-          command: |
-            cd vote-gov-nvrf-app
-            echo $NVRF_PDF_WRITE | tee /tmp/key.txt
-            gh auth login --with-token < /tmp/key.txt
-            gh pr create --title "Update NVRF PDF" --body "Upload the new NVRF PDF from eac.gov. This is an automated job from CircleCI" || true
+# turning off job until review of pdf can be done
+  # update-nvrf:
+  #   docker:
+  #     - image: cimg/base:stable
+  #   environment:
+  #     URL: https://www.eac.gov/sites/default/files/eac_assets/1/6/Federal_Voter_Registration_ENG.pdf
+  #     NVRF_FILE_NAME: Federal_Voter_Registration_ENG.pdf
+  #     NEW_BRANCH_NAME: upload-nvrf-pdf
+  #   steps:
+  #     #Install gh
+  #     - gh/install
+  #     - run:
+  #         name: Git Clone and Config
+  #         command: |
+  #           GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone -b "update-nvrf-pdf" "$CIRCLE_REPOSITORY_URL"
+  #           cd vote-gov-nvrf-app
+  #           git config user.email "circleci@df52e93b2563.(none)"
+  #           git config user.name "Pipeline Commit"
+  #     - run:
+  #         name: Fetch NVRF from eac.gov
+  #         command: |
+  #           curl -o Federal_Voter_Registration_ENG.pdf $URL
+  #     #Save pdf as an artifact
+  #     - store_artifacts:
+  #         path: Federal_Voter_Registration_ENG.pdf
+  #         destination: /pdf-files
+  #     # Create a variable to store the PDF artifact
+  #     - run:
+  #         name: Replace current NVRF
+  #         command: |
+  #           cd vote-gov-nvrf-app
+  #           artifacts=$(curl -X GET "https://circleci.com/api/v2/project/github/usagov/vote-gov-nvrf-app/$CIRCLE_BUILD_NUM/artifacts" \
+  #           -H "Accept: application/json" \
+  #           -u "$NVRF_PDF_WRITE:")
+  #           echo "read -r -d '' STORED_ARTIFACTS \<< 'EOF_ARTIFACTS'" >> $BASH_ENV
+  #           echo "$artifacts" >> $BASH_ENV
+  #           echo "EOF_ARTIFACTS" >> $BASH_ENV
+  #           cd public/files
+  #           rm $NVRF_FILE_NAME
+  #           echo $STORED_ARTIFACTS > $NVRF_FILE_NAME
+  #     - run:
+  #         name: Create Pull Request
+  #         shell: /bin/bash
+  #         command: |
+  #           cd vote-gov-nvrf-app
+  #           echo $NVRF_PDF_WRITE | tee /tmp/key.txt
+  #           gh auth login --with-token < /tmp/key.txt
+  #           gh pr create --title "Update NVRF PDF" --body "Upload the new NVRF PDF from eac.gov. This is an automated job from CircleCI" || true
   cypress-testing:
     docker:
       - image: cypress/included:cypress-13.3.0-node-20.6.1-chrome-116.0.5845.187-1-ff-117.0-edge-116.0.1938.76-1
@@ -70,13 +71,14 @@ workflows:
   main-workflow:
     jobs:
       - cypress-testing
-  update-nvrf-workflow:
-    jobs:
-      - update-nvrf
-    triggers:
-      - schedule:
-          cron: '0 0 * * 5'
-          filters:
-            branches:
-              only:
-                - stage
+# turning off job until review of pdf can be done
+  # update-nvrf-workflow:
+  #   jobs:
+  #     - update-nvrf
+  #   triggers:
+  #     - schedule:
+  #         cron: '0 0 * * 5'
+  #         filters:
+  #           branches:
+  #             only:
+  #               - stage


### PR DESCRIPTION
ticket: [Vote-2278](https://cm-jira.usa.gov/browse/VOTE-2728)

Purpose: To Disable the NVRF PDF job in the pipeline 

Testing: Verify that the job is commented out and check that the Cypress tests are still passing 