### PR TITLE
Vote-2725: Load PDF on App Load

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,8 @@ import PathSelection from 'Views/PathSelection.jsx';
 import MultiStepForm from 'Views/MultiStepForm.jsx';
 import {fetchData, fetchStaticData, sanitizeDOM} from 'Utils/JsonHelper.jsx';
 import { HelmetProvider } from "react-helmet-async";
+import loadPdf from './Utils/pdfLoader';
+
 
 const currentStateId = document.getElementById('root').getAttribute('data-stateId');
 const returnPath = document.getElementById('root').getAttribute('data-returnPath');
@@ -15,6 +17,16 @@ function App() {
   const [cards, setCards] = useState('');
   const [fieldContent, setFieldContent] = useState('')
   const [stringContent, setStringContent] = useState('')
+
+  const [pdfDoc, setPdfDoc] = useState(null);
+  const [form, setForm] = useState(null);
+
+  useEffect(() => {
+    loadPdf().then(({ pdfDoc, form }) => {
+      setPdfDoc(pdfDoc);
+      setForm(form);
+    });
+  }, []);
 
   useEffect(() => {
     fetchData("states.json", setStates);
@@ -146,6 +158,8 @@ function App() {
                     registrationPath={registrationPath}
                     getFormStep={getFormStep}
                     stringContent={stringContent}
+                    pdfDoc={pdfDoc}
+                    form={form}
                 />}
 
               {step >= 1 &&

--- a/src/Utils/GenerateFilledPDF_en.jsx
+++ b/src/Utils/GenerateFilledPDF_en.jsx
@@ -1,17 +1,9 @@
-import { PDFDocument} from 'pdf-lib';
 import download from "downloadjs";
+import loadPdf from './pdfLoader';
 
 const GenerateFilledPDF = async function (btnType,formData,pagesKept) {
-    // Fetch the PDF with form fields
-    const lang = document.documentElement.lang;
-    const locale = lang !== "en" ? `/${lang}` : "";
-    const formUrl = `/data${locale}/Federal_Voter_Registration_${lang}.pdf`;
-    const formPdfBytes = await fetch(formUrl).then(res => res.arrayBuffer())
-    // Load a PDF with form fields
-    const pdfDoc = await PDFDocument.load(formPdfBytes)
-
-    // Get the form containing all the fields
-    const form = pdfDoc.getForm()
+    // Fetch the PDF with form field
+    const { pdfDoc, form } = await loadPdf();
 
     //-------- Get PDF Fields by machine name ------------------
     const citizen = form.getRadioGroup('citizen');

--- a/src/Utils/GenerateFilledPDF_es.jsx
+++ b/src/Utils/GenerateFilledPDF_es.jsx
@@ -1,18 +1,9 @@
-import { PDFDocument} from 'pdf-lib';
 import download from "downloadjs";
+import loadPdf from './pdfLoader';
 
 const GenerateFilledPDF = async function (btnType,formData,pagesKept) {
-    // Fetch the PDF with form fields
-    const lang = document.documentElement.lang;
-    //TEST SPANISH const lang = "es";
-    const locale = lang !== "en" ? `/${lang}` : "";
-    const formUrl = `/data${locale}/Federal_Voter_Registration_${lang}.pdf`;
-    const formPdfBytes = await fetch(formUrl).then(res => res.arrayBuffer())
-    // Load a PDF with form fields
-    const pdfDoc = await PDFDocument.load(formPdfBytes)
-
-    // Get the form containing all the fields
-    const form = pdfDoc.getForm()
+   // Fetch the PDF with form field
+   const { pdfDoc, form } = await loadPdf();
 
     //-------- Get PDF Fields by machine name ------------------
     const citizen = form.getDropdown('citizen'); //TEMP spanish condition field type

--- a/src/Utils/pdfLoader.jsx
+++ b/src/Utils/pdfLoader.jsx
@@ -1,0 +1,13 @@
+import { PDFDocument } from 'pdf-lib';
+
+const loadPdf = async () => {
+  const lang = document.documentElement.lang;
+  const locale = lang!== "en"? `/${lang}` : "";
+  const formUrl = `/data${locale}/Federal_Voter_Registration_${lang}.pdf`;
+  const formPdfBytes = await fetch(formUrl).then(res => res.arrayBuffer())
+  const pdfDoc = await PDFDocument.load(formPdfBytes)
+  const form = pdfDoc.getForm()
+  return { pdfDoc, form };
+};
+
+export default loadPdf;


### PR DESCRIPTION
Ticket: [Vote-2725](https://cm-jira.usa.gov/browse/VOTE-2725)

Description:  This PR will load the NVRF PDF when the app mounts to ensure that the file is able to be accessed by the user 

Solution:  

1. Created a new file that takes the upload script and added to the utils folder 
2. Added a `useEffect` to the app.jsx file and added the probs to the multistep form component so that it would be loaded when the app starts up
3. Updated the generatepdf files to pull the data from the spirit file to still have access 

Testing: 

1. Loading up the app and complete the form
2. Verify that you can both download and open the pdf in a new tab and that info is till saving as expected 