### PR TITLE
Vote-2809: Add Fallback if NVRF pages is left empty

### DIFF
--- a/src/Utils/GenerateFilledPDF_en.jsx
+++ b/src/Utils/GenerateFilledPDF_en.jsx
@@ -132,18 +132,25 @@ const GenerateFilledPDF = async function (btnType,formData,pagesKept) {
 
     //-------------End PDF Fill---------------
 
-    //Remove unneccessary pages
-    let shift = 0;
-    const totalPages = pdfDoc.getPageCount();
-    let pageCount = totalPages;
-    let pagesKeptArray = pagesKept.split(',');
-    for(let i = 0; i < totalPages; i++){
-        if(!pagesKeptArray.includes(i.toString())){
-            pdfDoc.removePage(i - shift);
-            shift++;
-            pageCount--;
-        }
-    }
+// Remove unneccessary pages
+let shift = 0;
+const totalPages = pdfDoc.getPageCount();
+let pageCount = totalPages;
+let pagesKeptArray = pagesKept.split(',');
+
+// Check if pagesKept is empty or undefined
+if (!pagesKept || pagesKept.trim() === '') {
+  // If pagesKept is empty, render the full PDF
+pagesKeptArray = Array.from({ length: totalPages }, (_, i) => i.toString());
+}
+
+for (let i = 0; i < totalPages; i++) {
+if (!pagesKeptArray.includes(i.toString())) {
+    pdfDoc.removePage(i - shift);
+    shift++;
+    pageCount--;
+}
+}
 
     // Rearrange pages
     const genInstrutPages = pagesKeptArray.splice(0,2);

--- a/src/Utils/GenerateFilledPDF_es.jsx
+++ b/src/Utils/GenerateFilledPDF_es.jsx
@@ -132,18 +132,25 @@ const GenerateFilledPDF = async function (btnType,formData,pagesKept) {
 
     //-------------End PDF Fill---------------
 
-    //Remove unneccessary pages
-    let shift = 0;
-    const totalPages = pdfDoc.getPageCount();
-    let pageCount = totalPages;
-    let pagesKeptArray = pagesKept.split(',');
-    for(let i = 0; i < totalPages; i++){
-        if(!pagesKeptArray.includes(i.toString())){
-            pdfDoc.removePage(i - shift);
-            shift++;
-            pageCount--;
-        }
-    }
+// Remove unneccessary pages
+let shift = 0;
+const totalPages = pdfDoc.getPageCount();
+let pageCount = totalPages;
+let pagesKeptArray = pagesKept.split(',');
+
+// Check if pagesKept is empty or undefined
+if (!pagesKept || pagesKept.trim() === '') {
+  // If pagesKept is empty, render the full PDF
+pagesKeptArray = Array.from({ length: totalPages }, (_, i) => i.toString());
+}
+
+for (let i = 0; i < totalPages; i++) {
+if (!pagesKeptArray.includes(i.toString())) {
+    pdfDoc.removePage(i - shift);
+    shift++;
+    pageCount--;
+}
+}
 
     // Rearrange pages
     const genInstrutPages = pagesKeptArray.splice(0,2);


### PR DESCRIPTION
**Ticket:** [Vote-2809](https://cm-jira.usa.gov/browse/VOTE-2809)

**Description:**  This PR will add a fall back to the generate PDF function to still render a full version of the PDF if in the CMS the page numbers are not saved.  This will allow for a user to still have access to the PDF and their saved data. 

This update was made to both English and Spanish to help catch any issue that might happened with the NVRF page setting.

**Solution:**  Adding a conditional statement to the part of the function that removes the unneeded pages. 

**Testing:** 
1. Pull down local and start up app 
2. Open the `states.json` file under `nvrf/assets` folder.  
3. Do a search for `"nvrf_pages_list":"1,2,3,4,7"` when you find it make sure it is for alabama and clear out the number so it should look like this `"nvrf_pages_list":""`
4. Fill out the form and at the delivery option be sure to choose both options and verify that the full pdf is available and that the data you inputed is saved
5. Follow up test, revert the change to the `states.json` file and repeat filling out the form and verify that the pdf is now loading as expected with only the needed pages. 