### PR TITLE
VOTE-2113: Analytics for the next buttons

### DIFF
--- a/data/es/strings.json
+++ b/data/es/strings.json
@@ -22,5 +22,7 @@
     "analyticsStepLabel5": "Confirmation page",
     "analyticsStepLabel6": "PDF Delivery page",
     "analyticsEligibilityTitle": "Before you get started page",
-    "analyticsPathSelectionTitle": "Path Selection page"
+    "analyticsPathSelectionTitle": "Path Selection page",
+    "analyticsPDFTabButton": "NVRF_button_pdf_tab",
+    "analyticsPDFDownloadButton": "NVRF_button_download"
 }

--- a/data/es/strings.json
+++ b/data/es/strings.json
@@ -14,5 +14,11 @@
     "select": "-Elija-",
     "download": "Descargue el formulario",
     "mailDeadlineLabel": "Plazo de registro por correo:",
-    "idSelectionAriaLabel": "Choose identification type"
+    "idSelectionAriaLabel": "Choose identification type",
+    "analyticsStepLabel1": "Personal information page",
+    "analyticsStepLabel2": "Address and location page",
+    "analyticsStepLabel3": "Identification page",
+    "analyticsStepLabel4": "Political party page",
+    "analyticsStepLabel5": "Confirmation page",
+    "analyticsStepLabel6": "PDF Delivery page"
 }

--- a/data/es/strings.json
+++ b/data/es/strings.json
@@ -21,6 +21,6 @@
     "analyticsStepLabel4": "Political party page",
     "analyticsStepLabel5": "Confirmation page",
     "analyticsStepLabel6": "PDF Delivery page",
-    "analyticsEligibilityTitle": "Before you get started",
-    "analyticsPathSelectionTitle": "Path Selection"
+    "analyticsEligibilityTitle": "Before you get started page",
+    "analyticsPathSelectionTitle": "Path Selection page"
 }

--- a/data/es/strings.json
+++ b/data/es/strings.json
@@ -14,15 +14,5 @@
     "select": "-Elija-",
     "download": "Descargue el formulario",
     "mailDeadlineLabel": "Plazo de registro por correo:",
-    "idSelectionAriaLabel": "Choose identification type",
-    "analyticsStepLabel1": "Personal information page",
-    "analyticsStepLabel2": "Address and location page",
-    "analyticsStepLabel3": "Identification page",
-    "analyticsStepLabel4": "Political party page",
-    "analyticsStepLabel5": "Confirmation page",
-    "analyticsStepLabel6": "PDF Delivery page",
-    "analyticsEligibilityTitle": "Before you get started page",
-    "analyticsPathSelectionTitle": "Path Selection page",
-    "analyticsPDFTabButton": "NVRF_button_pdf_tab",
-    "analyticsPDFDownloadButton": "NVRF_button_download"
+    "idSelectionAriaLabel": "Choose identification type"
 }

--- a/data/strings.json
+++ b/data/strings.json
@@ -22,5 +22,7 @@
     "analyticsStepLabel5": "Confirmation page",
     "analyticsStepLabel6": "PDF Delivery page",
     "analyticsEligibilityTitle": "Before you get started page",
-    "analyticsPathSelectionTitle": "Path Selection page"
+    "analyticsPathSelectionTitle": "Path Selection page",
+    "analyticsPDFTabButton": "NVRF_button_pdf_tab",
+    "analyticsPDFDownloadButton": "NVRF_button_download"
 }

--- a/data/strings.json
+++ b/data/strings.json
@@ -21,6 +21,6 @@
     "analyticsStepLabel4": "Political party page",
     "analyticsStepLabel5": "Confirmation page",
     "analyticsStepLabel6": "PDF Delivery page",
-    "analyticsEligibilityTitle": "Before you get started",
-    "analyticsPathSelectionTitle": "Path Selection"
+    "analyticsEligibilityTitle": "Before you get started page",
+    "analyticsPathSelectionTitle": "Path Selection page"
 }

--- a/data/strings.json
+++ b/data/strings.json
@@ -14,5 +14,11 @@
     "select": "- Select -",
     "download": "Download your mail-in form",
     "mailDeadlineLabel": "Mail-in registration deadline:",
-    "idSelectionAriaLabel": "Choose identification type"
+    "idSelectionAriaLabel": "Choose identification type",
+    "analyticsStepLabel1": "Personal information page",
+    "analyticsStepLabel2": "Address and location page",
+    "analyticsStepLabel3": "Identification page",
+    "analyticsStepLabel4": "Political party page",
+    "analyticsStepLabel5": "Confirmation page",
+    "analyticsStepLabel6": "PDF Delivery page"
 }

--- a/data/strings.json
+++ b/data/strings.json
@@ -14,15 +14,5 @@
     "select": "- Select -",
     "download": "Download your mail-in form",
     "mailDeadlineLabel": "Mail-in registration deadline:",
-    "idSelectionAriaLabel": "Choose identification type",
-    "analyticsStepLabel1": "Personal information page",
-    "analyticsStepLabel2": "Address and location page",
-    "analyticsStepLabel3": "Identification page",
-    "analyticsStepLabel4": "Political party page",
-    "analyticsStepLabel5": "Confirmation page",
-    "analyticsStepLabel6": "PDF Delivery page",
-    "analyticsEligibilityTitle": "Before you get started page",
-    "analyticsPathSelectionTitle": "Path Selection page",
-    "analyticsPDFTabButton": "NVRF_button_pdf_tab",
-    "analyticsPDFDownloadButton": "NVRF_button_download"
+    "idSelectionAriaLabel": "Choose identification type"
 }

--- a/src/Views/Eligibility.jsx
+++ b/src/Views/Eligibility.jsx
@@ -21,6 +21,11 @@ function Eligibility(props) {
     const contentBodyParts = contentBody.split("@reg_confirm_eligibility");
     const eligibilityInstructions = sanitizeDOM(eligibility.instructions);
 
+    //Analytics values - do not change or translate
+    const analyticsLabels = {
+        eligibilityTitle: "Before you get started page",
+    }
+
     const mailDeadline = () => (
         <ul>
             <li dangerouslySetInnerHTML= {{__html: stateContent.postmarked_mail_deadline || stateContent.received_mail_deadline }}/>
@@ -44,7 +49,7 @@ function Eligibility(props) {
         <Form id="eligibility" autoComplete="off" className={'margin-top-2'} style={{maxWidth: 'none'}}
               onSubmit={(e) => {
                   e.preventDefault(), props.handleNext(),
-                  dataLayer.push({'NVRF_page_title': stringContent.analyticsEligibilityTitle, 'event': 'NVRF_STEP_SUBMIT' })
+                  dataLayer.push({'NVRF_page_title': analyticsLabels.eligibilityTitle, 'event': 'NVRF_STEP_SUBMIT' })
               }}>
             <div className="input-parent" data-test="checkBox">
                 <Label className={'margin-top-1'}>

--- a/src/Views/Eligibility.jsx
+++ b/src/Views/Eligibility.jsx
@@ -27,20 +27,6 @@ function Eligibility(props) {
         </ul>
     );
 
-    //Start Analytics
-    const [title, setTitle] = useState('');
-    useEffect(() => {
-        setTitle(stringContent.analyticsEligibilityTitle);
-    },[]);
-
-    useEffect(() => {
-        //only push if the title is set
-        if (title != ''){
-            dataLayer.push({'NVRF_page_title': title});
-        }
-    },[title]);
-    // End Analytics
-
     return (
         <>
             {returnPath && (
@@ -57,7 +43,8 @@ function Eligibility(props) {
 
         <Form id="eligibility" autoComplete="off" className={'margin-top-2'} style={{maxWidth: 'none'}}
               onSubmit={(e) => {
-                  e.preventDefault(), props.handleNext()
+                  e.preventDefault(), props.handleNext(),
+                  dataLayer.push({'NVRF_page_title': stringContent.analyticsEligibilityTitle, 'event': 'NVRF_STEP_SUBMIT' })
               }}>
             <div className="input-parent" data-test="checkBox">
                 <Label className={'margin-top-1'}>

--- a/src/Views/FormPages/Delivery.jsx
+++ b/src/Views/FormPages/Delivery.jsx
@@ -22,6 +22,12 @@ function Delivery(props) {
         };
     };
 
+     //Analytics values - do not change or translate
+     const analyticsLabels = {
+        pdfTabButton: "NVRF_button_pdf_tab",
+        pdfDownloadButton: "NVRF_button_download"
+    }
+
     if (content) {
         const delivery = content.find(item => item.uuid === "229f283c-6a70-43f6-a80f-15cfa158f062");
         const deliveryBody = sanitizeDOM(delivery.body.replace("@state_name", props.stateData.name).replace("@mailing_address_inst", state.mailing_address_inst));
@@ -51,7 +57,7 @@ function Delivery(props) {
                 <Button data-test="pdfBtnNewTab"
                     onClick={() => {
                         GenerateFilledPDF('newTab', props.fieldData, props.stateData.nvrf_pages_list);
-                        dataLayer.push({'NVRF_PDF_button': stringContent.analyticsPDFTabButton, 'event': "NVRF_PDF_BUTTON_CLICK"});
+                        dataLayer.push({'NVRF_PDF_button': analyticsLabels.pdfTabButton, 'event': "NVRF_PDF_BUTTON_CLICK"});
                     }}
                 type="submit">
                     <span>{stringContent.newTab}</span>
@@ -62,7 +68,7 @@ function Delivery(props) {
                 <Button data-test="pdfBtnDownload"
                     onClick={() => {
                         GenerateFilledPDF('download', props.fieldData, props.stateData.nvrf_pages_list);
-                        dataLayer.push({'NVRF_PDF_button': stringContent.analyticsPDFDownloadButton, 'event': "NVRF_PDF_BUTTON_CLICK"});
+                        dataLayer.push({'NVRF_PDF_button': analyticsLabels.pdfDownloadButton, 'event': "NVRF_PDF_BUTTON_CLICK"});
                     }} type="submit">
                     <span>{stringContent.download}</span>
                 </Button>

--- a/src/Views/FormPages/Delivery.jsx
+++ b/src/Views/FormPages/Delivery.jsx
@@ -51,7 +51,7 @@ function Delivery(props) {
                 <Button data-test="pdfBtnNewTab"
                     onClick={() => {
                         GenerateFilledPDF('newTab', props.fieldData, props.stateData.nvrf_pages_list);
-                        dataLayer.push({'NVRF_button_click': 'NVRF_button_pdf_tab'});
+                        dataLayer.push({'NVRF_button': stringContent.analyticsPDFTabButton, 'event': "NVRF_PDF_DElIVERY"});
                     }}
                 type="submit">
                     <span>{stringContent.newTab}</span>
@@ -62,7 +62,7 @@ function Delivery(props) {
                 <Button data-test="pdfBtnDownload"
                     onClick={() => {
                         GenerateFilledPDF('download', props.fieldData, props.stateData.nvrf_pages_list);
-                        dataLayer.push({'NVRF_button_click': 'NVRF_button_download'});
+                        dataLayer.push({'NVRF_button': stringContent.analyticsPDFDownloadButton, 'event': "NVRF_PDF_DElIVERY"});
                     }} type="submit">
                     <span>{stringContent.download}</span>
                 </Button>

--- a/src/Views/FormPages/Delivery.jsx
+++ b/src/Views/FormPages/Delivery.jsx
@@ -51,7 +51,7 @@ function Delivery(props) {
                 <Button data-test="pdfBtnNewTab"
                     onClick={() => {
                         GenerateFilledPDF('newTab', props.fieldData, props.stateData.nvrf_pages_list);
-                        dataLayer.push({'NVRF_button': stringContent.analyticsPDFTabButton, 'event': "NVRF_PDF_DElIVERY"});
+                        dataLayer.push({'NVRF_PDF_button': stringContent.analyticsPDFTabButton, 'event': "NVRF_PDF_BUTTON_CLICK"});
                     }}
                 type="submit">
                     <span>{stringContent.newTab}</span>
@@ -62,7 +62,7 @@ function Delivery(props) {
                 <Button data-test="pdfBtnDownload"
                     onClick={() => {
                         GenerateFilledPDF('download', props.fieldData, props.stateData.nvrf_pages_list);
-                        dataLayer.push({'NVRF_button': stringContent.analyticsPDFDownloadButton, 'event': "NVRF_PDF_DElIVERY"});
+                        dataLayer.push({'NVRF_PDF_button': stringContent.analyticsPDFDownloadButton, 'event': "NVRF_PDF_BUTTON_CLICK"});
                     }} type="submit">
                     <span>{stringContent.download}</span>
                 </Button>

--- a/src/Views/MultiStepForm.jsx
+++ b/src/Views/MultiStepForm.jsx
@@ -26,6 +26,15 @@ function MultiStepForm(props) {
     const scrollToTop = document.getElementById('scroll-to-top');
     const lang = document.documentElement.lang;
 
+    //Analytics values - do not change or translate
+    const analyticsLabels = {
+        stepLabel1 : "Personal information page",
+        stepLabel2 : "Address and location page",
+        stepLabel3 : "Identification page",
+        stepLabel4 : "Political party page",
+        stepLabel5 : "Confirmation page",
+        stepLabel6 : "PDF Delivery page",
+    }
     //Field data controls
     const [fieldData, setFieldData] = useState({
         title:'', first_name: '', middle_name: '', last_name: '', suffix:'',
@@ -272,7 +281,7 @@ function MultiStepForm(props) {
             <Form autoComplete="off" id="nvrf" className={'margin-top-5'} style={{ maxWidth:'none' }}
                 onSubmit={(e) => {
                     handleSubmit(e), handleNext(),
-                    pushPageTitleDataLayer(stringContent["analyticsStepLabel"+step])
+                    pushPageTitleDataLayer(analyticsLabels["stepLabel"+step])
                 }}
             >
                 {step === 1 &&

--- a/src/Views/MultiStepForm.jsx
+++ b/src/Views/MultiStepForm.jsx
@@ -379,7 +379,7 @@ function MultiStepForm(props) {
                         onClick={() => {
                             nextStepValidation(),
                             focusError('nvrf'),
-                            pushPageTitleDataLayer('test title') }}
+                            pushPageTitleDataLayer(navContent["step_label_"+step]) }}
                     text={nextButtonText(step)}/>
                 )}
             </Form>

--- a/src/Views/MultiStepForm.jsx
+++ b/src/Views/MultiStepForm.jsx
@@ -103,7 +103,7 @@ function MultiStepForm(props) {
     }
 
     const pushPageTitleDataLayer = (title) => {
-        dataLayer.push({'NVRF_page_title': title });
+        dataLayer.push({'NVRF_page_title': title, 'event': 'NVRF_STEP_SUBMIT' });
     }
 
     const handleSubmit = (e) => {
@@ -269,7 +269,12 @@ function MultiStepForm(props) {
                 </>
             }
 
-            <Form autoComplete="off" id="nvrf" className={'margin-top-5'} style={{ maxWidth:'none' }} onSubmit={(e) => {handleSubmit(e), handleNext()}}>
+            <Form autoComplete="off" id="nvrf" className={'margin-top-5'} style={{ maxWidth:'none' }}
+                onSubmit={(e) => {
+                    handleSubmit(e), handleNext(),
+                    pushPageTitleDataLayer(stringContent["analyticsStepLabel"+step])
+                }}
+            >
                 {step === 1 &&
                     <PersonalInfo
                         state={props.state}
@@ -378,8 +383,7 @@ function MultiStepForm(props) {
                     <NextButton stringContent={stringContent} type={'submit'}
                         onClick={() => {
                             nextStepValidation(),
-                            focusError('nvrf'),
-                            pushPageTitleDataLayer(navContent["step_label_"+step]) }}
+                            focusError('nvrf') }}
                     text={nextButtonText(step)}/>
                 )}
             </Form>

--- a/src/Views/MultiStepForm.jsx
+++ b/src/Views/MultiStepForm.jsx
@@ -102,6 +102,10 @@ function MultiStepForm(props) {
         }
     }
 
+    const pushPageTitleDataLayer = (title) => {
+        dataLayer.push({'NVRF_page_title': title });
+    }
+
     const handleSubmit = (e) => {
         e.preventDefault(e);
     }
@@ -371,10 +375,14 @@ function MultiStepForm(props) {
                 }
 
                 {step != 6 && (
-                    <NextButton stringContent={stringContent} type={'submit'} onClick={() => {nextStepValidation(), focusError('nvrf')}} text={nextButtonText(step)}/>
+                    <NextButton stringContent={stringContent} type={'submit'}
+                        onClick={() => {
+                            nextStepValidation(),
+                            focusError('nvrf'),
+                            pushPageTitleDataLayer('test title') }}
+                    text={nextButtonText(step)}/>
                 )}
             </Form>
-
             {/* Load Touchpoints feedback form */}
             {step === 6 && lang === 'en' &&
                 <>

--- a/src/Views/PathSelection.jsx
+++ b/src/Views/PathSelection.jsx
@@ -16,17 +16,6 @@ function PathSelection(props) {
     const cardOneBody = sanitizeDOM(cardOne.body);
     const cardTwoBody = sanitizeDOM(cardTwo.body);
 
-    //Start Analytics
-    const [title, setTitle] = useState('');
-    useEffect(() => {
-        setTitle(stringContent.analyticsPathSelectionTitle);
-    },[]);
-
-    useEffect(() => {
-        dataLayer.push({'NVRF_page_title': title});
-    },[title]);
-    // End Analytics
-
     return (
         <>
             <BackButton stringContent={stringContent} type={'button'} onClick={props.handlePrev} text={navContent.back.eligibility_req}/>
@@ -51,7 +40,7 @@ function PathSelection(props) {
                             onClick={() => {
                                 props.getRegPath("update"),
                                 props.handleNext(),
-                                dataLayer.push({'NVRF_path': 'update_registration_path'})
+                                dataLayer.push({'NVRF_path': 'update_registration_path', 'NVRF_page_title': stringContent.analyticsPathSelectionTitle, 'event': 'NVRF_STEP_SUBMIT'})
                             }}>
                             <span>{cardOne.button_label}</span>
                             <Icon.ArrowForward aria-label={stringContent.forwardIcon} style={{margin: "-3px -3px -3px 4px"}}/>
@@ -74,7 +63,7 @@ function PathSelection(props) {
                             onClick={() => {
                                 props.getRegPath("new"),
                                 props.handleNext(),
-                                dataLayer.push({'NVRF_path': 'new_registration_path'})
+                                dataLayer.push({'NVRF_path': 'new_registration_path', 'NVRF_page_title': stringContent.analyticsPathSelectionTitle, 'event': 'NVRF_STEP_SUBMIT'})
                             }}>
                             <span>{cardTwo.button_label}</span>
                             <Icon.ArrowForward aria-label={stringContent.forwardIcon} style={{margin: "-3px -3px -3px 4px"}}/>

--- a/src/Views/PathSelection.jsx
+++ b/src/Views/PathSelection.jsx
@@ -16,6 +16,11 @@ function PathSelection(props) {
     const cardOneBody = sanitizeDOM(cardOne.body);
     const cardTwoBody = sanitizeDOM(cardTwo.body);
 
+    //Analytics values - do not change or translate
+    const analyticsLabels = {
+        pathSelectionTitle: "Path Selection page",
+    }
+
     return (
         <>
             <BackButton stringContent={stringContent} type={'button'} onClick={props.handlePrev} text={navContent.back.eligibility_req}/>
@@ -40,7 +45,7 @@ function PathSelection(props) {
                             onClick={() => {
                                 props.getRegPath("update"),
                                 props.handleNext(),
-                                dataLayer.push({'NVRF_path': 'update_registration_path', 'NVRF_page_title': stringContent.analyticsPathSelectionTitle, 'event': 'NVRF_STEP_SUBMIT'})
+                                dataLayer.push({'NVRF_path': 'update_registration_path', 'NVRF_page_title': analyticsLabels.pathSelectionTitle, 'event': 'NVRF_STEP_SUBMIT'})
                             }}>
                             <span>{cardOne.button_label}</span>
                             <Icon.ArrowForward aria-label={stringContent.forwardIcon} style={{margin: "-3px -3px -3px 4px"}}/>
@@ -63,7 +68,7 @@ function PathSelection(props) {
                             onClick={() => {
                                 props.getRegPath("new"),
                                 props.handleNext(),
-                                dataLayer.push({'NVRF_path': 'new_registration_path', 'NVRF_page_title': stringContent.analyticsPathSelectionTitle, 'event': 'NVRF_STEP_SUBMIT'})
+                                dataLayer.push({'NVRF_path': 'new_registration_path', 'NVRF_page_title': analyticsLabels.pathSelectionTitle, 'event': 'NVRF_STEP_SUBMIT'})
                             }}>
                             <span>{cardTwo.button_label}</span>
                             <Icon.ArrowForward aria-label={stringContent.forwardIcon} style={{margin: "-3px -3px -3px 4px"}}/>


### PR DESCRIPTION
Jira ticket: https://cm-jira.usa.gov/browse/VOTE-2113

Description: Add dataLayer event to the Next Button that pushes the current page (just completed step) to GTM.

Test steps:
1. Open the form locally
2. Fill out the form until the Delivery page. Use the update path. 
3. Click the "Open in a new tab" PDF button.
4. Open the console and type 'dataLayer'. Press Enter.
5. Verify the following values are present in the dataLayer. The indexes do not matter, but they should be in this order. You can ignore the other click events done by default by GTM.

NVRF_page_title: 'Before you get started page', event: 'NVRF_STEP_SUBMIT'
NVRF_path: 'update_registration_path', NVRF_page_title: 'Path Selection page', event: 'NVRF_STEP_SUBMIT'
NVRF_page_title: 'Personal information page', event: 'NVRF_STEP_SUBMIT'
NVRF_page_title: 'Address and location page', event: 'NVRF_STEP_SUBMIT'
NVRF_page_title: 'Identification page', event: 'NVRF_STEP_SUBMIT'
NVRF_page_title: 'Political party page', event: 'NVRF_STEP_SUBMIT'
NVRF_page_title: 'Confirmation page', event: 'NVRF_STEP_SUBMIT'
NVRF_PDF_button: 'NVRF_button_pdf_tab', event: 'NVRF_PDF_BUTTON_CLICK'
NVRF_page_title: 'PDF Delivery page', event: 'NVRF_STEP_SUBMIT'

Note: If you go back in the form, the values will be sent again to GTM. This is okay, because we are using sessions in GA4 to avoid double counting values.