### PR TITLE
Vote-2847: Update to Spanish Strings for screen readers

### DIFF
--- a/public/es/nvrf/data/strings.json
+++ b/public/es/nvrf/data/strings.json
@@ -5,14 +5,13 @@
     "month": "Mes",
     "day": "Día",
     "year": "Año",
-    "backIcon": "back arrow icon",
-    "forwardIcon": "forward arrow icon",
-    "selectState": "Select your state or territory",
-    "selectStateAriaLabel": "State selection dropdown menu",
+    "backIcon": "icono de flecha hacia atrás",
+    "forwardIcon": "icono de flecha hacia adelante",
+    "selectState": "Seleccione su estado o territorio",
+    "selectStateAriaLabel": "Lista de sugerencias de estados y territorios",
     "lastUpdated": "@state_name información actualizada por última vez",
-    "emailLabel": "Voter Contact",
     "select": "-Elija-",
     "download": "Descargue el formulario",
     "mailDeadlineLabel": "Plazo de registro por correo:",
-    "idSelectionAriaLabel": "Choose identification type"
+    "idSelectionAriaLabel": "Seleccione el tipo de identificación"
 }

--- a/public/nvrf/data/strings.json
+++ b/public/nvrf/data/strings.json
@@ -10,7 +10,6 @@
     "selectState": "Select your state or territory",
     "selectStateAriaLabel": "State selection dropdown menu",
     "lastUpdated": "@state_name information last updated ",
-    "emailLabel": "Voter Contact",
     "select": "- Select -",
     "download": "Download your mail-in form",
     "mailDeadlineLabel": "Mail-in registration deadline:",

--- a/src/Views/FormPages/PersonalInfo.jsx
+++ b/src/Views/FormPages/PersonalInfo.jsx
@@ -105,9 +105,9 @@ function PersonalInfo(props){
             }}>
                 <div className="input-parent">
                     <Label className="text-bold" htmlFor="voter-contact" aria-hidden="true">
-                    {stringContent.emailLabel}<span className='required-text'>*</span>
+                    Voter Contact<span className='required-text'>*</span>
                     </Label>
-                    <span className="usa-hint">{stringContent.emailLabel}</span>
+                    <span className="usa-hint">Voter Contact</span>
                     <TextInput
                         data-test="email"
                         id="voter-contact"


### PR DESCRIPTION
Ticket: [Vote-2847](https://cm-jira.usa.gov/browse/VOTE-2847)

Description: Updating screen reader labels with new spanish string translations 

Testing: 
1. Review files changed and ensure that the right translation are made 
2. Navigate to the personal info page and do a search in the DOM for the string `Voter Contact` and ensure it is present and sill hidden to trap bots that might crawl that page 