### PR TITLE
VOTE-2984 Revert pdf event name change

### DIFF
--- a/src/Views/FormPages/Delivery.jsx
+++ b/src/Views/FormPages/Delivery.jsx
@@ -57,7 +57,7 @@ function Delivery(props) {
                 <Button data-test="pdfBtnNewTab"
                     onClick={() => {
                         GenerateFilledPDF('newTab', props.fieldData, props.stateData.nvrf_pages_list, props.pdfDoc, props.form);
-                        dataLayer.push({'NVRF_PDF_button': analyticsLabels.pdfTabButton, 'event': "NVRF_PDF_BUTTON_CLICK"});
+                        dataLayer.push({'NVRF_button_click': analyticsLabels.pdfTabButton, 'event': "NVRF_PDF_BUTTON_CLICK"});
                     }}
                 type="submit">
                     <span>{stringContent.newTab}</span>
@@ -68,7 +68,7 @@ function Delivery(props) {
                 <Button data-test="pdfBtnDownload"
                     onClick={() => {
                         GenerateFilledPDF('download', props.fieldData, props.stateData.nvrf_pages_list, props.pdfDoc, props.form);
-                        dataLayer.push({'NVRF_PDF_button': analyticsLabels.pdfDownloadButton, 'event': "NVRF_PDF_BUTTON_CLICK"});
+                        dataLayer.push({'NVRF_button_click': analyticsLabels.pdfDownloadButton, 'event': "NVRF_PDF_BUTTON_CLICK"});
                     }} type="submit">
                     <span>{stringContent.download}</span>
                 </Button>


### PR DESCRIPTION
https://cm-jira.usa.gov/browse/VOTE-2984

Revert a name change to GA tag on PDF buttons

Testing:
1. Go through the form until the last page.
2. Click both the PDF download, and PDF new tab buttons.
3. Open the console, type "dataLayer" and press Enter
4. Confirm the following lines are present in the dataLayer array. EventID does not matter.

{NVRF_button_click: 'NVRF_button_pdf_tab', event: 'NVRF_PDF_BUTTON_CLICK', gtm.uniqueEventId: 50}
{NVRF_button_click: 'NVRF_button_download', event: 'NVRF_PDF_BUTTON_CLICK', gtm.uniqueEventId: 54}