### PR TITLE
Vote-3115: adding aria-live for error text

### DIFF
--- a/src/Components/FieldContainer.jsx
+++ b/src/Components/FieldContainer.jsx
@@ -33,7 +33,7 @@ function FieldContainer({ fieldType, inputData, saveFieldData, fieldData, string
         )}
         {renderField(fieldType)}
         {inputData.error_msg && (
-          <span id={`${inputData.id}` + '_error'} role="alert" className={'vote-error-text'} data-test="errorText">
+          <span id={`${inputData.id}` + '_error'} role="alert" aria-live="assertive" className={'vote-error-text'} data-test="errorText">
             {inputData.error_msg}
           </span>
         )}

--- a/src/Components/FieldsetContainer.jsx
+++ b/src/Components/FieldsetContainer.jsx
@@ -22,7 +22,7 @@ function FieldsetContainer({ fieldType, inputData, saveFieldData, dateFormat, fi
                         {inputData.help_text}
                     </span>
                     {renderField(fieldType)}
-                    <span id={`${inputData.id}` + '_error'} role="alert" className={'vote-error-text'} data-test="errorText">
+                    <span id={`${inputData.id}` + '_error'} role="alert" aria-live="assertive" className={'vote-error-text'} data-test="errorText">
                         {inputData.error_msg}
                     </span>
                 </Fieldset>

--- a/src/Views/FormPages/Confirmation.jsx
+++ b/src/Views/FormPages/Confirmation.jsx
@@ -197,7 +197,7 @@ function Confirmation(props) {
                     onInvalid={(e) => e.target.setCustomValidity(' ')}
                     onInput={(e) => e.target.setCustomValidity('')}
                 />
-                <span id="first-name-error" role="alert" className={'vote-error-text'} data-test="errorText">
+                <span id="first-name-error" role="alert" aria-live="assertive" className={'vote-error-text'} data-test="errorText">
                     {getFieldError("73e74065-fd5a-43c0-907c-268120e34bc3")}
                 </span>
             </div>

--- a/src/Views/FormPages/Identification.jsx
+++ b/src/Views/FormPages/Identification.jsx
@@ -75,7 +75,7 @@ function Identification(props){
                             {(noIdFieldReq) && <option key="id-none" value="none">{noIdField.label}</option>}
                         </React.Fragment>
                         </Select>
-                        <span id="id-selection_error" role="alert" className={'vote-error-text'} data-test="errorText">
+                        <span id="id-selection_error" role="alert" aria-live="assertive" className={'vote-error-text'} data-test="errorText">
                             {props.idType === '' && stateIDField.error_msg}
                         </span>
                     </div>


### PR DESCRIPTION
Ticket: [Vote-3115](https://cm-jira.usa.gov/browse/VOTE-3115)

Purpose: This pr will add `aria-live` to error messages 

Testing:
1. start local and trigger an error while having voice over on and confirm that the error message is being read out loud

Follow up work will need to update error message to have `Error:` before 