### PR TITLE
VOTE-3316 Bug Fix: Error text announced by screenreader before input

### DIFF
--- a/src/Components/FieldComponents/TextInputField.jsx
+++ b/src/Components/FieldComponents/TextInputField.jsx
@@ -9,7 +9,7 @@ function TextInputField({inputData, saveFieldData, fieldData}) {
 
   const hintId = inputData.id + '-hint';
   const errorId = inputData.id + '_error';
-  const [a11yAnnounce, setA11yAnnounce] = useState(inputData.help_text ? hintId : errorId);
+  const [a11yAnnounce, setA11yAnnounce] = useState(hintId);
 
   return (
     <TextInput


### PR DESCRIPTION
Ticket: https://cm-jira.usa.gov/browse/VOTE-3316

Description: A field's error message was annouced right after the label, and before any user input.
This ticket sets the allyAnnouce variable to be initialized as the hint text, even when empty. The error text is the aria label only is the error is present.

Test steps:
1. Navigate to the Personal info page and turn on a screen reader.
2. Tab to first name. Confirm the label is read, but not the error message.
3. Tab to the next field without entering any data.
4. Confirm the middle name label and help text is read out.
5. Tab back to first name. Confirm the error message is announced by the screen reader. Move on without entering any data.
6. Click the next button. Confirm the screen reader takes you to first name reads out the error message.
7. Enter data into the first name field. Confirm the page submits.