### PR TITLE
VOTE-2858 Add underline to enabled links in step indicator

### DIFF
--- a/src/Components/ProgressBar.css
+++ b/src/Components/ProgressBar.css
@@ -23,6 +23,10 @@
       color: #005ea2;
     }
   }
+  
+  .usa-step-indicator__segment-label {
+    text-decoration: underline;
+  }
 }
 
 .usa-step-indicator .usa-step-indicator__segment-label {

--- a/src/Components/ProgressBar.jsx
+++ b/src/Components/ProgressBar.jsx
@@ -58,7 +58,7 @@ function ProgressBar(props) {
                                label={steps[stepList[step]].label}
                                data-analytics={"Step indicator " + steps[stepList[step]].label}
                                status={stepProgress(step)}
-                               tabIndex={stepProgress(step) === "complete" ? 0 : null}
+                               tabIndex={stepProgress(step) === "complete" && currentStep !== finalStep ? 0 : null}
                                onKeyDown={(e) => {
                                  if (e.key === "Enter" && stepProgress(step) === "complete") {
                                    setStep(step)


### PR DESCRIPTION
Jira ticket: https://cm-jira.usa.gov/browse/VOTE-2858

Add underline to the link text within the step indicator.

Test steps:
1. Fill out the form, and on each page, confirm the previous completed steps now have underlined text.
2. Confirm the underlines are removed on the last page (the links are no longer enabled for complete steps after PDF generation)