### PR TITLE
VOTE-3476: enforce small button css

### DIFF
--- a/src/VoteError.css
+++ b/src/VoteError.css
@@ -15,5 +15,5 @@
 }
 
 .usa-button.usa-button--small {
-  padding: 0.6rem 0.8rem;
+  padding: 0.6rem 0.8rem !important;
 }


### PR DESCRIPTION
https://cm-jira.usa.gov/browse/VOTE-3476

This should have no change in the styling of the edit buttons on the confirm page.